### PR TITLE
fix: remove gibberish data from the funding progress view

### DIFF
--- a/app/components/hypercerts-grid-view/card.tsx
+++ b/app/components/hypercerts-grid-view/card.tsx
@@ -26,17 +26,14 @@ const Card = ({ hypercert }: { hypercert: Hypercert }) => {
 	return (
 		<Link href={`/hypercert/${hypercertId}`} passHref>
 			<article className="group relative overflow-hidden rounded-2xl border border-border bg-muted">
-				<div className="h-[320px] w-full">
-					<div className="relative h-full w-full overflow-hidden">
-						<Image
-							// src={`/api/hypercert/${hypercert_id}/image`}
-							src={image ?? ""}
-							alt={name ?? "Untitled"}
-							fill
-							sizes="300px"
-							className="h-auto w-full object-contain object-center transition group-hover:scale-[1.05]"
-						/>
-					</div>
+				<div className="h-[320px] w-full overflow-hidden p-4">
+					<Image
+						src={image ?? ""}
+						alt={name ?? "Untitled"}
+						height={500}
+						width={500}
+						className="h-auto w-full object-contain object-center transition group-hover:scale-[1.05]"
+					/>
 				</div>
 				<section className="absolute top-4 left-4 flex space-x-1 opacity-100 transition-opacity duration-150 ease-out group-hover:opacity-100 md:opacity-0">
 					<div className="rounded-md border border-white/60 bg-black px-2 py-0.5 text-white text-xs shadow-sm">

--- a/app/hypercert/[hypercertId]/components/evaluation-details.tsx
+++ b/app/hypercert/[hypercertId]/components/evaluation-details.tsx
@@ -1,12 +1,19 @@
+"use client";
+import type { FullHypercert } from "@/app/graphql-queries/hypercerts";
 import { Button } from "@/components/ui/button";
 import EthAvatar from "@/components/ui/eth-avatar";
 import { EvervaultCard } from "@/components/ui/evervault-card";
 import { Separator } from "@/components/ui/separator";
 import UserChip from "@/components/user-chip";
 import { Info, ShieldCheck } from "lucide-react";
-import React from "react";
+import React, { useState } from "react";
 
-const EvaluationDetails = () => {
+const EvaluationDetails = ({ hypercert }: { hypercert: FullHypercert }) => {
+	const { attestations } = hypercert;
+	const attesters = new Set(
+		attestations.map((attestation) => attestation.attester),
+	);
+	const [viewingAll, setViewingAll] = useState(false);
 	return (
 		<div className="group overflow-hidden">
 			<EvervaultCard>
@@ -15,31 +22,41 @@ const EvaluationDetails = () => {
 					<span className="font-bold text-lg">Verified by Gainforest</span>
 				</div>
 			</EvervaultCard>
-			<div className="flex w-full flex-col items-center gap-1 px-8 py-4">
-				<span className="text-center text-muted-foreground leading-none">
-					This hypercerts and the work it represents have been verified by
-				</span>
-				<span className="text-center font-bold text-foreground text-xl">
-					GainForest.Earth
-				</span>
-			</div>
-			{false && (
+			{attesters.size === 0 && (
+				<div className="flex w-full flex-col items-center gap-1 px-8 py-4">
+					<span className="text-center text-muted-foreground leading-none">
+						This hypercerts and the work it represents have been verified by
+					</span>
+					<span className="text-center font-bold text-foreground text-xl">
+						GainForest.Earth
+					</span>
+				</div>
+			)}
+			{attesters.size > 0 && (
 				<div className="mt-4 flex w-full flex-col gap-2">
 					<span className="font-bold text-muted-foreground text-sm">
 						Other Evaluators:
 					</span>
 					<ul className="flex flex-wrap items-center gap-1">
-						<UserChip address="0x012345678910" />
-						<UserChip address="0x012345678910" />
-						<UserChip address="0x012345678910" />
-						<UserChip address="0x012345678910" />
-						<UserChip address="0x012345678910" />
-						<li className="flex h-8 items-center justify-center rounded-full border border-border bg-muted px-2 text-sm">
-							+2
-						</li>
-						<Button variant={"ghost"} size={"sm"}>
-							View all
-						</Button>
+						{[...attesters]
+							.slice(0, viewingAll ? undefined : 3)
+							.map((attester) => (
+								<UserChip address={attester as `0x${string}`} key={attester} />
+							))}
+						{attesters.size > 3 && (
+							<>
+								<li className="flex h-8 items-center justify-center rounded-full border border-border bg-muted px-2 text-sm">
+									+{attesters.size - 3}
+								</li>
+								<Button
+									variant={"ghost"}
+									size={"sm"}
+									onClick={() => setViewingAll(!viewingAll)}
+								>
+									{viewingAll ? "View less" : "View all"}
+								</Button>
+							</>
+						)}
 					</ul>
 				</div>
 			)}

--- a/app/hypercert/[hypercertId]/components/funding-progress-view.tsx
+++ b/app/hypercert/[hypercertId]/components/funding-progress-view.tsx
@@ -23,8 +23,7 @@ const FundingProgressView = ({ hypercert }: { hypercert: FullHypercert }) => {
 				<div className="flex flex-col items-start">
 					<span className="text-muted-foreground">Reached</span>
 					<span className="font-bold text-xl">
-						{pricePerPercentInUSD}$
-						{(percentCompleted * pricePerPercentInUSD).toFixed()}
+						${(percentCompleted * pricePerPercentInUSD).toFixed()}
 					</span>
 				</div>
 				<div className="flex flex-col items-end">

--- a/app/hypercert/[hypercertId]/components/right-content.tsx
+++ b/app/hypercert/[hypercertId]/components/right-content.tsx
@@ -17,7 +17,7 @@ const RightContent = ({ hypercert }: { hypercert: FullHypercert }) => {
 			)}
 			<Contributors hypercert={hypercert} />
 			<SectionWrapper title={"Verification"}>
-				<EvaluationDetails />
+				<EvaluationDetails hypercert={hypercert} />
 			</SectionWrapper>
 		</div>
 	);


### PR DESCRIPTION
This PR is for fixing the display of funding progress view. Here's how it looked earlier:
![image](https://github.com/user-attachments/assets/8be063ed-9fcb-4894-9fdb-f4e3ec4c9fed)
