### PR TITLE
fix: lower the displayed progress when the percentage is 0

### DIFF
--- a/app/components/shared/progress.tsx
+++ b/app/components/shared/progress.tsx
@@ -18,7 +18,7 @@ const Progress = ({
 			<motion.div
 				className="h-full bg-primary"
 				initial={{ width: "0%" }}
-				animate={{ width: `${5 + (percentage / 100) * 95}%` }}
+				animate={{ width: `${2 + (percentage / 100) * 99}%` }}
 				transition={{ duration: 0.5 }}
 			/>
 		</div>


### PR DESCRIPTION
The progress bar (for funding) seems too much filled even when the percentage is 0. This PR fixes that, by lowering the filled progress bar.
[Screenshots could not be taken, due to recent change in environment variables. Please merge #29 so the visual changes can be produced.]