### PR TITLE
fix: remove emojis from scopes in hypercert card

### DIFF
--- a/app/submit/components/hypercert-form.tsx
+++ b/app/submit/components/hypercert-form.tsx
@@ -191,7 +191,7 @@ const HypercertForm = () => {
 			areaBadges.push(`⭔ ${geoJSONArea} ha`);
 		}
 		if (areaActivity) {
-			areaBadges.push(`🌱 ${areaActivity}`);
+			areaBadges.push(`${areaActivity}`);
 		}
 
 		if (tags) {
@@ -208,7 +208,7 @@ const HypercertForm = () => {
 				areaBadges.push(`⭔ ${geoJSONArea} ha`);
 			}
 			if (areaActivity) {
-				areaBadges.push(`🌱 ${areaActivity}`);
+				areaBadges.push(`${areaActivity}`);
 			}
 			setBadges(areaBadges);
 		}


### PR DESCRIPTION
The purpose of this PR is to remove emojis from the scopes. while creating and submiting a hypercert, because the hypercert card might get rendered wrong way.