### PR TITLE
Hypercert minter checks the current environment

### DIFF
--- a/hooks/use-hypercerts-client.ts
+++ b/hooks/use-hypercerts-client.ts
@@ -9,7 +9,7 @@ export const useHypercertClient = () => {
 	const client = useMemo(
 		() =>
 			new HypercertClient({
-				environment: "test",
+				environment: `${process.env.NEXT_PUBLIC_DEPLOY_ENV} === 'production'` ? 'production' : 'test',
 				// @ts-ignore - wagmi and viem have different typing
 				walletClient,
 			}),


### PR DESCRIPTION
The hypercert minter should mint from 'production' if we're in a prod environment, and in 'test' if were in a test environment