### PR TITLE
adjusting title size

### DIFF
--- a/app/submit/components/hypercert-card.tsx
+++ b/app/submit/components/hypercert-card.tsx
@@ -102,7 +102,7 @@ const HypercertCard = forwardRef<HTMLDivElement, HypercertCardProps>(
 				</section>
 				<section className="flex h-[246px] flex-col justify-between rounded-t-xl border-black border-t-[1px] bg-white p-3 pt-4">
 					<h5
-						className="line-clamp-3 text-ellipsis py-1 font-semibold text-[28px] text-slate-800 leading-[30px] tracking-[-0.03em]"
+						className="line-clamp-3 text-ellipsis py-1 font-semibold text-[25px] text-slate-800 leading-[27px] tracking-[-0.03em]"
 						title={title}
 					>
 						{title}


### PR DESCRIPTION
<img width="352" alt="Screenshot 2025-02-03 at 04 12 24" src="https://github.com/user-attachments/assets/8e192634-58fe-4c53-87d0-23d6f0a4919b" />

vs how it was before

<img width="360" alt="Screenshot 2025-02-03 at 04 13 29" src="https://github.com/user-attachments/assets/8c16bbcf-7e52-4099-9a75-7d96b9390093" />
