### PR TITLE
Change hypercert amount

### DIFF
--- a/app/hypercert/[hypercertId]/loading.tsx
+++ b/app/hypercert/[hypercertId]/loading.tsx
@@ -44,7 +44,7 @@ const Loading = () => {
 			<div className="flex w-full max-w-6xl flex-col gap-2 p-8">
 				<Link href={"/"}>
 					<Button variant={"link"} className="gap-2 p-0">
-						<ChevronLeft size={20} /> View all hypercerts
+						<ChevronLeft size={20} /> View all ecocerts
 					</Button>
 				</Link>
 				<div className="flex w-full flex-col items-start gap-12 md:flex-row md:items-center">

--- a/hooks/use-mint-hypercert.ts
+++ b/hooks/use-mint-hypercert.ts
@@ -48,7 +48,7 @@ const useMintHypercert = () => {
       setContactInfo(contactInfo);
       return client.mintClaim(
         metaData,
-        parseEther("1"),
+        100_000_000n,
         TransferRestrictions.FromCreatorOnly
       );
     },


### PR DESCRIPTION
According to @bitbeckers we should change `parseEther("1")` to `100_000_000n` to provide the best balance between 6 and 18 decimal currencies for sale listings

