### PR TITLE
fix the long awaited nextjs caching bug

### DIFF
--- a/app/utils/graphql.ts
+++ b/app/utils/graphql.ts
@@ -15,6 +15,15 @@ export type ApiError = {
 		| "ABORT";
 };
 
+const headers = {
+	"Cache-Control": "no-cache",
+	Pragma: "no-cache",
+	"x-timestamp": Date.now().toString(),
+	// Add any other headers you need
+	// 'Authorization': 'Bearer your-token',
+	// 'Content-Type': 'application/json',
+};
+
 export async function fetchGraphQL<ResponseType, VariablesType>(
 	apiUrl: string,
 	query: TadaDocumentNode<ResponseType, VariablesType, unknown>,
@@ -26,7 +35,7 @@ export async function fetchGraphQL<ResponseType, VariablesType>(
 			console.log("calling from fetchGraphQL", testingLog);
 			console.log("making request");
 		}
-		const response = await request(apiUrl, query, variables ?? {});
+		const response = await request(apiUrl, query, variables ?? {}, headers);
 		if (testingLog) {
 			console.log("got response");
 		}


### PR DESCRIPTION
This PR
finally
fixes the caching bug that felt almost impossible.

# Bug description
### NextJS caches all `fetch` calls
Since the graphql requests were being made from the server... each time a client requested for the data, NextJS would capture the user's request, check if any existing data for the request is already present, and if it's there... it just didn't make the graphql request.
The requests were being made by a function `request` that exists in an npm package. It used `fetch` under the hood, that caused the NextJS caching. It could have been easily prevented by adding additional headers about cache control.... but the fetch function was abstracted in a package.

# Bug fix
Noticed, that the `request` from the npm package, supports for passing the headers....
Tried passing the non-cache headers in the function, and it worked!