### PR TITLE
Display buyers chronlogically

### DIFF
--- a/app/hypercert/[hypercertId]/components/support.tsx
+++ b/app/hypercert/[hypercertId]/components/support.tsx
@@ -92,6 +92,10 @@ const Support = ({ hypercert }: { hypercert: FullHypercert }) => {
 		}
 	}
 
+	const newestToOldestSales = hypercert.sales.sort((a, b) => {
+		return Number(b.creationBlockTimestamp - a.creationBlockTimestamp);
+	});
+
 	return (
 		<Wrapper
 			buyFraction={
@@ -110,8 +114,8 @@ const Support = ({ hypercert }: { hypercert: FullHypercert }) => {
 		>
 			<div className="flex w-full flex-col gap-2">
 				<ul className="flex w-full flex-col gap-1">
-					{hypercert.sales
-						?.map((sale) => {
+					{newestToOldestSales
+						.map((sale) => {
 							const saleCurrency = sale.currency;
 							let currencySymbol: string;
 							if (


### PR DESCRIPTION
# Changes
Add a sorting function to sort the sales in reverse chronological order by time and display them.

![image](https://github.com/user-attachments/assets/c6937672-4285-4324-b012-8e826f0ef06b)
