### PR TITLE
feat: display newest created hypercert first

### DIFF
--- a/app/graphql-queries/hypercerts.ts
+++ b/app/graphql-queries/hypercerts.ts
@@ -75,6 +75,7 @@ export type Hypercert = {
 	unitsForSale?: bigint;
 	pricePerPercentInUSD?: number;
 	buyerCount: number;
+	creationBlockTimestamp: bigint;
 };
 
 const fetchHypercertById = async (hypercertId: string): Promise<Hypercert> => {
@@ -121,6 +122,8 @@ const fetchHypercertById = async (hypercertId: string): Promise<Hypercert> => {
 		),
 		pricePerPercentInUSD: pricePerPercentInUSDNumber,
 		buyerCount: uniqueBuyers.size,
+		creationBlockTimestamp:
+			typeCastApiResponseToBigInt(hypercert.creation_block_timestamp) ?? 0n,
 	};
 };
 

--- a/app/graphql-queries/sales.ts
+++ b/app/graphql-queries/sales.ts
@@ -39,7 +39,7 @@ export type SaleByUser = {
 	currency: string;
 	currencyAmount: bigint;
 	unitsBought: bigint;
-	creationBlockTimestamp: bigint;
+	saleTimestamp: bigint;
 	transactionHash: string;
 	id: string;
 	hypercert: SaleByUserHypercert;
@@ -65,7 +65,7 @@ export const fetchSalesByUser = async (userAddress: `0x${string}`) => {
 			currencyAmount:
 				typeCastApiResponseToBigInt(sale.currency_amount ?? 0) ?? 0n,
 			unitsBought: typeCastApiResponseToBigInt(sale.amounts?.[0] ?? 0) ?? 0n,
-			creationBlockTimestamp:
+			saleTimestamp:
 				typeCastApiResponseToBigInt(sale.creation_block_timestamp) ?? 0n,
 			transactionHash: sale.transaction_hash,
 			id: sale.id,
@@ -103,7 +103,7 @@ export type SaleByHypercert = {
 	currency: string;
 	currencyAmount: bigint;
 	unitsBought: bigint;
-	creationBlockTimestamp: bigint;
+	saleTimestamp: bigint;
 	transactionHash: string;
 	id: string;
 	buyer: string;
@@ -124,7 +124,7 @@ export const fetchSalesByHypercert = async (hypercertId: string) => {
 			currencyAmount:
 				typeCastApiResponseToBigInt(sale.currency_amount ?? 0) ?? 0n,
 			unitsBought: typeCastApiResponseToBigInt(sale.amounts?.[0] ?? 0) ?? 0n,
-			creationBlockTimestamp:
+			saleTimestamp:
 				typeCastApiResponseToBigInt(sale.creation_block_timestamp) ?? 0n,
 			transactionHash: sale.transaction_hash,
 			id: sale.id,

--- a/app/graphql-queries/sales.ts
+++ b/app/graphql-queries/sales.ts
@@ -17,7 +17,6 @@ const getSalesByUserQuery = graphql(`
           hypercert_id
           metadata {
             work_scope
-            image
             description
             name
           }
@@ -31,7 +30,6 @@ export type SaleByUserHypercert = {
 	hypercertId: string;
 	metadata: {
 		workScope?: string[];
-		image?: string;
 		description?: string;
 		name?: string;
 	};
@@ -60,7 +58,7 @@ export const fetchSalesByUser = async (userAddress: `0x${string}`) => {
 		const hypercert = sale.hypercert;
 		if (!hypercert || !hypercert.hypercert_id) return null;
 
-		const { work_scope, image, description, name } = hypercert.metadata ?? {};
+		const { work_scope, description, name } = hypercert.metadata ?? {};
 
 		return {
 			currency: sale.currency,
@@ -75,7 +73,6 @@ export const fetchSalesByUser = async (userAddress: `0x${string}`) => {
 				hypercertId: hypercert.hypercert_id,
 				metadata: {
 					workScope: work_scope ?? undefined,
-					image: image ?? undefined,
 					description: description ?? undefined,
 					name: name ?? undefined,
 				},

--- a/app/graphql-queries/templates.ts
+++ b/app/graphql-queries/templates.ts
@@ -1,5 +1,6 @@
 export const hypercert = `
     data {
+        creation_block_timestamp
         units
         contract {
           chain_id

--- a/app/graphql-queries/user-hypercerts.ts
+++ b/app/graphql-queries/user-hypercerts.ts
@@ -72,6 +72,8 @@ export const fetchHypercertsByUserId = async (
 			),
 			pricePerPercentInUSD: pricePerPercentInUSDNumber,
 			buyerCount: uniqueBuyers.size,
+			creationBlockTimestamp:
+				typeCastApiResponseToBigInt(hypercert.creation_block_timestamp) ?? 0n,
 		} satisfies Hypercert;
 	});
 

--- a/app/profile/[address]/components/content/created-hypercerts/card.tsx
+++ b/app/profile/[address]/components/content/created-hypercerts/card.tsx
@@ -1,6 +1,6 @@
 import type { Hypercert } from "@/app/graphql-queries/hypercerts";
 import { Button } from "@/components/ui/button";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -20,9 +20,9 @@ export default function Card({ hypercert }: { hypercert: Hypercert }) {
 				/>
 				{hypercertId !== undefined && (
 					<div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100">
-						<Link href={`/hypercert/${hypercertId}`} target="_blank" passHref>
+						<Link href={`/hypercert/${hypercertId}`}>
 							<Button variant={"secondary"} className="gap-2">
-								View Hypercert <ArrowUpRight size={20} />
+								View Hypercert <ArrowRight size={20} />
 							</Button>
 						</Link>
 					</div>

--- a/app/profile/[address]/components/content/created-hypercerts/index.tsx
+++ b/app/profile/[address]/components/content/created-hypercerts/index.tsx
@@ -17,9 +17,12 @@ const NoCreatedHypercerts = () => {
 
 const CreatedHypercerts = ({ hypercerts }: { hypercerts: Hypercert[] }) => {
 	if (hypercerts.length === 0) return <NoCreatedHypercerts />;
+	const newestSortedHypercerts = hypercerts.sort((a, b) =>
+		Number(b.creationBlockTimestamp - a.creationBlockTimestamp),
+	);
 	return (
 		<div className="grid w-full grid-cols-1 gap-4 lg:grid-cols-2">
-			{hypercerts.map((hypercert) => {
+			{newestSortedHypercerts.map((hypercert) => {
 				return <Card key={hypercert.hypercertId} hypercert={hypercert} />;
 			})}
 		</div>

--- a/app/profile/[address]/components/content/supported-hypercerts/card.tsx
+++ b/app/profile/[address]/components/content/supported-hypercerts/card.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import type { CombinedSale } from "../../../page";
@@ -33,9 +33,9 @@ export default function Card({ combinedSale }: { combinedSale: CombinedSale }) {
 				/>
 				{hypercertId !== undefined && (
 					<div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100">
-						<Link href={`/hypercert/${hypercertId}`} target="_blank" passHref>
+						<Link href={`/hypercert/${hypercertId}`}>
 							<Button variant={"secondary"} className="gap-2">
-								View Hypercert <ArrowUpRight size={20} />
+								View Hypercert <ArrowRight size={20} />
 							</Button>
 						</Link>
 					</div>

--- a/app/profile/[address]/components/content/supported-hypercerts/card.tsx
+++ b/app/profile/[address]/components/content/supported-hypercerts/card.tsx
@@ -9,7 +9,7 @@ export default function Card({ combinedSale }: { combinedSale: CombinedSale }) {
 	const { totalAmountInUSD } = combinedSale;
 	const {
 		hypercertId,
-		metadata: { name, description, image, workScope },
+		metadata: { name, description, workScope },
 	} = combinedSale.hypercert;
 
 	return (
@@ -24,8 +24,7 @@ export default function Card({ combinedSale }: { combinedSale: CombinedSale }) {
 
 			<div className="relative flex h-[200px] w-full items-start justify-center overflow-hidden rounded-t-2xl bg-muted p-4">
 				<Image
-					// src={`/api/hypercert/${hypercert_id}/image`}
-					src={image ?? ""}
+					src={`/api/hypercert/${hypercertId}`}
 					alt={name ?? "Untitled"}
 					height={200}
 					width={200}

--- a/app/profile/[address]/components/content/supported-hypercerts/card.tsx
+++ b/app/profile/[address]/components/content/supported-hypercerts/card.tsx
@@ -24,7 +24,7 @@ export default function Card({ combinedSale }: { combinedSale: CombinedSale }) {
 
 			<div className="relative flex h-[200px] w-full items-start justify-center overflow-hidden rounded-t-2xl bg-muted p-4">
 				<Image
-					src={`/api/hypercert/${hypercertId}`}
+					src={`/api/hypercert-image/${hypercertId}`}
 					alt={name ?? "Untitled"}
 					height={200}
 					width={200}

--- a/app/profile/[address]/components/content/supported-hypercerts/index.tsx
+++ b/app/profile/[address]/components/content/supported-hypercerts/index.tsx
@@ -21,9 +21,12 @@ const SupportedHypercerts = ({
 	combinedSales: CombinedSale[];
 }) => {
 	if (combinedSales.length === 0) return <NoSupportedHypercerts />;
+	const newestSortedCombinedSales = combinedSales.sort((a, b) =>
+		Number(b.lastSaleTimestamp - a.lastSaleTimestamp),
+	);
 	return (
 		<div className="grid w-full grid-cols-1 gap-4 lg:grid-cols-2">
-			{combinedSales.map((sale) => {
+			{newestSortedCombinedSales.map((sale) => {
 				return <Card key={sale.id} combinedSale={sale} />;
 			})}
 		</div>

--- a/app/profile/[address]/page.tsx
+++ b/app/profile/[address]/page.tsx
@@ -24,6 +24,7 @@ export type CombinedSale = {
 	unitsBought: bigint;
 	hypercert: SaleByUserHypercert;
 	id: string;
+	lastSaleTimestamp: bigint;
 };
 
 const combineSales = async (sales: SaleByUser[]) => {
@@ -60,6 +61,7 @@ const combineSales = async (sales: SaleByUser[]) => {
 				unitsBought: sale.unitsBought,
 				hypercert: sale.hypercert,
 				id: sale.id,
+				lastSaleTimestamp: sale.saleTimestamp,
 			});
 			continue;
 		}
@@ -68,6 +70,12 @@ const combineSales = async (sales: SaleByUser[]) => {
 		if (index === undefined) continue; // This will never happen.
 		combinedSales[index].totalAmountInUSD += amountInUSD;
 		combinedSales[index].unitsBought += sale.unitsBought;
+		combinedSales[index].lastSaleTimestamp = BigInt(
+			Math.max(
+				Number(combinedSales[index].lastSaleTimestamp),
+				Number(sale.saleTimestamp),
+			),
+		);
 	}
 
 	return combinedSales;


### PR DESCRIPTION
## Overview

1. Update the created hypercerts page to list all the created hypercerts in newest to oldest manner.
2. Update the link on each hypercert to open the hypercert in the same tab, rather than opening a new tab.
3. Add the image sideloading feature to the supported hypercerts page.
4. Update the supported hypercerts page to use the same sorting behaviour.

![image](https://github.com/user-attachments/assets/f92422f8-f896-4fd5-b6e1-d045814b6ada)
