### PR TITLE
fix: fix responsiveness on hypercert page for tabs

### DIFF
--- a/app/hypercert/[hypercertId]/components/left-content.tsx
+++ b/app/hypercert/[hypercertId]/components/left-content.tsx
@@ -78,7 +78,7 @@ const Metadata = ({ hypercert }: { hypercert: FullHypercert }) => {
 
 const LeftContent = ({ hypercert }: { hypercert: FullHypercert }) => {
 	return (
-		<div className="flex w-full flex-initial flex-col gap-6 md:w-auto md:flex-[3]">
+		<div className="flex w-full flex-initial flex-col gap-6 lg:w-auto lg:flex-[3]">
 			<div className="overflow-hidden rounded-2xl border border-border bg-beige-muted/80">
 				<VerificationIndicator />
 				<div className="flex w-full flex-col items-center justify-center p-2">

--- a/app/hypercert/[hypercertId]/components/right-content.tsx
+++ b/app/hypercert/[hypercertId]/components/right-content.tsx
@@ -7,7 +7,7 @@ import EvaluationDetails from "./evaluation-details";
 
 const RightContent = ({ hypercert }: { hypercert: FullHypercert }) => {
 	return (
-		<div className="flex w-full flex-initial flex-col gap-6 md:w-auto md:flex-[2]">
+		<div className="flex w-full flex-initial flex-col gap-6 lg:w-auto lg:flex-[2]">
 			{hypercert.uri && (
 				<SectionWrapper title={"Site Boundaries"}>
 					<div className="flex w-full items-center justify-center">

--- a/components/map-renderer.tsx
+++ b/components/map-renderer.tsx
@@ -79,7 +79,7 @@ export default function MapRenderer({ uri }: MapRendererProps) {
 	}, [uri]);
 
 	return (
-		<div className="flex aspect-square h-auto min-h-[300px] w-full max-w-[400px] flex-col items-center justify-center gap-2 overflow-hidden rounded-xl md:max-w-full">
+		<div className="flex aspect-square h-auto min-h-[300px] w-full max-w-[400px] flex-col items-center justify-center gap-2 overflow-hidden rounded-xl">
 			{error ? (
 				<>
 					<CircleAlert className="mb-4 text-muted-foreground/75" size={50} />


### PR DESCRIPTION
# Changes
- FIx the hypercert page responsiveness when viewing from tab sized devices.
# Before
![image](https://github.com/user-attachments/assets/1e161940-ce2c-47d3-81fa-024a651fc259)
# After
![image](https://github.com/user-attachments/assets/b15bd8d6-9a4e-4e85-83e1-0975fc411cb4)
