### PR TITLE
fix: fix pagination on homepage

### DIFF
--- a/app/components/hypercerts-grid-view/grid-view.tsx
+++ b/app/components/hypercerts-grid-view/grid-view.tsx
@@ -42,7 +42,7 @@ export function GridView({ hypercerts }: { hypercerts: Hypercert[] }) {
 		}
 	}, [filteredHypercerts]);
 
-	const itemsPerPage = 10;
+	const itemsPerPage = hypercerts.length;
 
 	const { currentPage, currentPageItems, loadPage, maxPage, needsPagination } =
 		usePagination<Hypercert>(filteredHypercerts, itemsPerPage);
@@ -96,12 +96,12 @@ export function GridView({ hypercerts }: { hypercerts: Hypercert[] }) {
 								itemsPerPage={itemsPerPage}
 							/>
 						)}
-						<VDPaginator
+						{/* <VDPaginator
 							needsPagination={needsPagination}
 							currentPage={currentPage}
 							maxPage={maxPage}
 							loadPage={loadPage}
-						/>
+						/> */}
 					</section>
 				}
 			</section>


### PR DESCRIPTION
# Changes
Display the correct no. of hypercerts visible and remove unnecessary paginator component.
<img width="525" alt="image" src="https://github.com/user-attachments/assets/fffbed7f-74f7-48cd-827b-f786387fb7cb" />
