### PR TITLE
fix: update the verification logic to check for hyperboard id

### DIFF
--- a/app/hypercert/[hypercertId]/components/VerificationIndicator.tsx
+++ b/app/hypercert/[hypercertId]/components/VerificationIndicator.tsx
@@ -1,8 +1,10 @@
 "use client";
 import GetVerifiedDialog from "@/app/components/get-verified-dialog";
 import useFullHypercert from "@/app/contexts/full-hypercert";
+import { fetchHypercertIDs } from "@/app/graphql-queries/hypercerts";
 import { verifiedAttestors } from "@/config/gainforest";
 import { cn } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, ShieldAlert, ShieldCheck } from "lucide-react";
 import React from "react";
 import { useAccount } from "wagmi";
@@ -10,13 +12,13 @@ import { useAccount } from "wagmi";
 const VerificationIndicator = () => {
 	const { address } = useAccount();
 	const hypercert = useFullHypercert();
-	const attesters = hypercert.attestations.map(
-		(attestation) => attestation.attester,
-	);
+	const { data: hyperboardIds } = useQuery({
+		queryKey: ["hypercert-ids-in-hyperboard"],
+		queryFn: fetchHypercertIDs,
+	});
 
-	const isVerified = attesters.some((attester) =>
-		verifiedAttestors.has(attester),
-	);
+	const isVerified = hyperboardIds?.some((id) => id === hypercert.hypercertId);
+
 	const isCreator =
 		hypercert.creatorAddress.toLowerCase() === address?.toLowerCase();
 

--- a/app/hypercert/[hypercertId]/components/VerificationIndicator.tsx
+++ b/app/hypercert/[hypercertId]/components/VerificationIndicator.tsx
@@ -12,7 +12,7 @@ import { useAccount } from "wagmi";
 const VerificationIndicator = () => {
 	const { address } = useAccount();
 	const hypercert = useFullHypercert();
-	const { data: hyperboardIds } = useQuery({
+	const { data: hyperboardIds, isLoading: hyperboardIdsLoading } = useQuery({
 		queryKey: ["hypercert-ids-in-hyperboard"],
 		queryFn: fetchHypercertIDs,
 	});
@@ -21,6 +21,8 @@ const VerificationIndicator = () => {
 
 	const isCreator =
 		hypercert.creatorAddress.toLowerCase() === address?.toLowerCase();
+
+	if (hyperboardIdsLoading) return null;
 
 	return (
 		<div

--- a/app/hypercert/[hypercertId]/components/evaluation-details.tsx
+++ b/app/hypercert/[hypercertId]/components/evaluation-details.tsx
@@ -1,28 +1,42 @@
 "use client";
 import GetVerifiedDialog from "@/app/components/get-verified-dialog";
-import type { FullHypercert } from "@/app/graphql-queries/hypercerts";
+import {
+	type FullHypercert,
+	fetchHypercertIDs,
+} from "@/app/graphql-queries/hypercerts";
 import { Button } from "@/components/ui/button";
 import { EvervaultCard } from "@/components/ui/evervault-card";
 import UserChip from "@/components/user-chip";
 import { verifiedAttestors } from "@/config/gainforest";
 import { cn } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, ShieldCheck } from "lucide-react";
+import Link from "next/link";
 import React, { useState } from "react";
+import { useAccount } from "wagmi";
 
 const EvaluationDetails = ({ hypercert }: { hypercert: FullHypercert }) => {
 	const { attestations } = hypercert;
+	const { address } = useAccount();
+	const isCreator =
+		address?.toLowerCase() === hypercert.creatorAddress.toLowerCase();
+
+	const { data: hyperboardIds } = useQuery({
+		queryKey: ["hypercert-ids-in-hyperboard"],
+		queryFn: fetchHypercertIDs,
+	});
+	const isVerifiedByGainForest = hyperboardIds?.some(
+		(id) => id === hypercert.hypercertId,
+	);
+
 	const attesters = new Set(
 		attestations.map((attestation) => attestation.attester),
 	);
 	const [viewingAll, setViewingAll] = useState(false);
 
-	const hasGainforestAttestation = [...attesters].some((attester) =>
-		verifiedAttestors.has(attester),
-	);
-
 	return (
 		<div className="group overflow-hidden">
-			{hasGainforestAttestation && (
+			{isVerifiedByGainForest && (
 				<EvervaultCard>
 					<div className="flex w-full items-center gap-2">
 						<ShieldCheck className="text-primary" size={24} />
@@ -30,39 +44,37 @@ const EvaluationDetails = ({ hypercert }: { hypercert: FullHypercert }) => {
 					</div>
 				</EvervaultCard>
 			)}
-			{attesters.size === 0 ? (
-				<div className="flex w-full flex-col items-center gap-4 px-8 py-4">
+			{attesters.size === 0 && (
+				<div className="flex w-full flex-col items-center gap-1 px-8 py-4">
 					<span className="text-center text-muted-foreground leading-none">
-						Verification allows you to display this hypercert in the ecocertain
-						homepage.
+						{isVerifiedByGainForest
+							? "This hypercert and its works have been verified by GainForest and is visible on the homepage."
+							: "This hypercert is not yet verified by GainForest, and cannot be accessed on the homepage."}
 					</span>
-					<a href="https://tally.so/r/w8rRxA" target="_blank" rel="noreferrer">
-						<Button size={"sm"} className="gap-2">
-							<ShieldCheck size={16} />
-							Get Verified
-						</Button>
-					</a>
+					{isCreator && (
+						<Link
+							href="https://tally.so/r/w8rRxA"
+							target="_blank"
+							rel="noreferrer"
+							className="mt-2"
+						>
+							<Button size={"sm"} className="gap-2">
+								<ShieldCheck size={16} />
+								Get Verified
+							</Button>
+						</Link>
+					)}
 				</div>
-			) : (
-				// Display subtitle if there are no attesters other than gainforest.
-				attesters.size === 1 &&
-				hasGainforestAttestation && (
-					<div className="flex w-full flex-col items-center gap-1 px-8 py-4">
-						<span className="text-center text-muted-foreground leading-none">
-							This hypercert and the work has been verified by Gainforest.
-						</span>
-					</div>
-				)
 			)}
 			{attesters.size > 0 && (
 				<div
 					className={cn(
 						"flex w-full flex-col gap-2",
-						hasGainforestAttestation ? "mt-4" : "",
+						isVerifiedByGainForest ? "mt-4" : "",
 					)}
 				>
 					<span className="font-bold text-muted-foreground text-sm">
-						{hasGainforestAttestation ? "Other Evaluators" : "Evaluators"}:
+						{isVerifiedByGainForest ? "Other Evaluators" : "Evaluators"}:
 					</span>
 					<ul className="flex flex-wrap items-center gap-1">
 						{[...attesters]

--- a/app/hypercert/[hypercertId]/components/evaluation-details.tsx
+++ b/app/hypercert/[hypercertId]/components/evaluation-details.tsx
@@ -21,7 +21,7 @@ const EvaluationDetails = ({ hypercert }: { hypercert: FullHypercert }) => {
 	const isCreator =
 		address?.toLowerCase() === hypercert.creatorAddress.toLowerCase();
 
-	const { data: hyperboardIds } = useQuery({
+	const { data: hyperboardIds, isLoading: hyperboardIdsLoading } = useQuery({
 		queryKey: ["hypercert-ids-in-hyperboard"],
 		queryFn: fetchHypercertIDs,
 	});
@@ -36,20 +36,21 @@ const EvaluationDetails = ({ hypercert }: { hypercert: FullHypercert }) => {
 
 	return (
 		<div className="group overflow-hidden">
-			{isVerifiedByGainForest && (
+			{/* {isVerifiedByGainForest && (
 				<EvervaultCard>
 					<div className="flex w-full items-center gap-2">
 						<ShieldCheck className="text-primary" size={24} />
 						<span className="font-bold text-lg">Verified by Gainforest</span>
 					</div>
 				</EvervaultCard>
-			)}
+			)} */}
 			{attesters.size === 0 && (
 				<div className="flex w-full flex-col items-center gap-1 px-8 py-4">
 					<span className="text-center text-muted-foreground leading-none">
-						{isVerifiedByGainForest
-							? "This hypercert and its works have been verified by GainForest and is visible on the homepage."
-							: "This hypercert is not yet verified by GainForest, and cannot be accessed on the homepage."}
+						{!hyperboardIdsLoading &&
+							(isVerifiedByGainForest
+								? "This hypercert and its works have been verified by GainForest and is visible on the homepage."
+								: "This hypercert is not yet verified by GainForest, and cannot be accessed on the homepage.")}
 					</span>
 					{isCreator && (
 						<Link
@@ -67,14 +68,9 @@ const EvaluationDetails = ({ hypercert }: { hypercert: FullHypercert }) => {
 				</div>
 			)}
 			{attesters.size > 0 && (
-				<div
-					className={cn(
-						"flex w-full flex-col gap-2",
-						isVerifiedByGainForest ? "mt-4" : "",
-					)}
-				>
+				<div className={cn("flex w-full flex-col gap-2")}>
 					<span className="font-bold text-muted-foreground text-sm">
-						{isVerifiedByGainForest ? "Other Evaluators" : "Evaluators"}:
+						Evaluators:
 					</span>
 					<ul className="flex flex-wrap items-center gap-1">
 						{[...attesters]


### PR DESCRIPTION
# Changes
Update the "Verified by GainForest" logic to check for the hyperboard id instead of checking for GainForest attesters.

<img width="846" alt="image" src="https://github.com/user-attachments/assets/85c9f9ee-d5bb-4ddd-9293-feb4ca92b04b" />
