### PR TITLE
fix: view the hypercert id in copy button on small devices

### DIFF
--- a/app/hypercert/[hypercertId]/components/copy-button.tsx
+++ b/app/hypercert/[hypercertId]/components/copy-button.tsx
@@ -20,7 +20,7 @@ const CopyButton = ({ text }: CopyButtonProps) => {
 			className="h-auto gap-2 rounded-full p-1 px-3"
 			onClick={() => copy(text)}
 		>
-			<span className="hidden md:inline">{truncateText}</span>
+			<span className="inline">{truncateText}</span>
 			{isCopied ? <Check size={12} /> : <Copy size={12} />}
 		</Button>
 	);

--- a/app/hypercert/[hypercertId]/page.tsx
+++ b/app/hypercert/[hypercertId]/page.tsx
@@ -71,7 +71,7 @@ export default async function HypercertPage({
 									</li>
 								))}
 							</ul>
-							<div className="mt-1 flex items-center gap-2 text-muted-foreground text-sm">
+							<div className="mt-3 flex flex-col items-start gap-2 text-muted-foreground text-sm md:flex-row md:items-center">
 								<CopyButton text={hypercertId} />
 								<Link
 									href={`https://app.hypercerts.org/hypercerts/${hypercertId}`}


### PR DESCRIPTION
# Changes
Display the full hypercert id in the copy button when viewing from smaller devices.

<img width="391" alt="image" src="https://github.com/user-attachments/assets/77f6d664-49f9-45b0-b8dc-6a86f137b0bd" />
