### PR TITLE
fix: make the card sizes uniform even if its coming soon

### DIFF
--- a/app/components/create-listing-dialog/price-form.tsx
+++ b/app/components/create-listing-dialog/price-form.tsx
@@ -102,7 +102,9 @@ const PriceForm = ({
 			<div className="flex items-start gap-2 rounded-lg border bg-muted/50 p-3 font-sans text-muted-foreground text-xs">
 				<Info className="mt-0.5 h-4 w-4 shrink-0" />
 				<p>
-					The price of an ecocert represents an estimate of all the costs required to create the specified environmental impact in your region and within the outlined timeframes. 
+					The price of an ecocert represents an estimate of all the costs
+					required to create the specified environmental impact in your region
+					and within the outlined timeframes.
 				</p>
 			</div>
 		</div>

--- a/app/components/hypercerts-grid-view/card.tsx
+++ b/app/components/hypercerts-grid-view/card.tsx
@@ -44,14 +44,14 @@ const Card = ({ hypercert }: { hypercert: Hypercert }) => {
 					</div>
 				</section>
 				<section
-					className="absolute bottom-0 w-full space-y-2 border-t border-t-border bg-background/90 p-4 backdrop-blur-md"
+					className="absolute bottom-0 flex w-full flex-col gap-2 border-t border-t-border bg-background/90 p-4 backdrop-blur-md"
 					style={{
 						boxShadow: "0 -10px 10px rgba(0, 0, 0, 0.1)",
 					}}
 				>
 					<p
 						className={cn(
-							"line-clamp-2 h-[2.56rem] flex-1 text-ellipsis break-words font-semibold text-lg leading-5",
+							"line-clamp-2 h-[2.56rem] text-ellipsis break-words font-semibold text-lg leading-5",
 							name
 								? "font-baskerville text-foreground"
 								: "text-muted-foreground",
@@ -60,19 +60,16 @@ const Card = ({ hypercert }: { hypercert: Hypercert }) => {
 						{name ?? "[Untitled]"}
 					</p>
 					<p
-						className={
-							"line-clamp-2 h-10 flex-1 text-ellipsis text-muted-foreground text-sm"
-						}
+						className={cn(
+							"text-ellipsis text-muted-foreground text-sm",
+							pricePerPercentInUSD === undefined
+								? "mb-2.5 line-clamp-5 h-auto min-h-[100px]"
+								: "line-clamp-2 h-10",
+						)}
 					>
 						{description ?? "..."}
 					</p>
-					{pricePerPercentInUSD === undefined ? (
-						<div className="flex w-full items-center justify-start text-muted-foreground text-sm">
-							{/* <span className="inline-block rounded-full bg-beige-muted px-2 text-beige-muted-foreground">
-								Not listed for sale
-							</span> */}
-						</div>
-					) : unitsForSale === 0n ? (
+					{pricePerPercentInUSD === undefined ? null : unitsForSale === 0n ? ( // </div> // 	</span> // 		Not listed for sale // 	<span className="inline-block rounded-full bg-beige-muted px-2 text-beige-muted-foreground"> // <div className="flex w-full items-center justify-start text-muted-foreground text-sm">
 						<div className="flex w-full items-center justify-start text-muted-foreground text-sm">
 							<span className="inline-block rounded-full bg-destructive/20 px-2 text-destructive">
 								Sold


### PR DESCRIPTION
# Changes
1. Add a conditional styling on the card description to show 5 lines and 2rems of margin if the hypercert is coming soon... so as to callibrate its size and make it uniform with the other cards.
<img width="985" alt="Screenshot 2025-04-03 at 7 21 20 PM" src="https://github.com/user-attachments/assets/858071cb-08ac-495a-bd40-22f9c07e8463" />
