### PR TITLE
fix: update geojson ipfs urls based on the pinning services

### DIFF
--- a/app/hypercert/[hypercertId]/components/site-boundaries.tsx
+++ b/app/hypercert/[hypercertId]/components/site-boundaries.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import QuickTooltip from "@/components/ui/quicktooltip";
-import { generateIPFSUrl, getMetadata } from "@/utils/metadata";
+import { generateEcocertainIPFSUrl, getMetadata } from "@/utils/metadata";
 import { validateMetaData } from "@hypercerts-org/sdk";
 import type { HypercertMetadata } from "@hypercerts-org/sdk";
 import { useQuery } from "@tanstack/react-query";
@@ -63,8 +63,8 @@ const getMapDataFromHypercertCID = async (
 		}
 
 		const cid = match[1];
-		const geojsonURL = generateIPFSUrl(cid);
-		const mapPreviewURL = `https://legacy.gainforest.app/?shapefile=https://gateway.pinata.cloud/ipfs/${cid}&showUI=false`;
+		const geojsonURL = generateEcocertainIPFSUrl(cid);
+		const mapPreviewURL = `https://legacy.gainforest.app/?shapefile=${geojsonURL}&showUI=false`;
 		const metadata = validationResult.data as HypercertMetadata;
 		return {
 			geojsonURL,

--- a/utils/metadata.ts
+++ b/utils/metadata.ts
@@ -1,11 +1,15 @@
 import { validateMetaData } from "@hypercerts-org/sdk";
 
-export const generateIPFSUrl = (cid: string) => {
+export const generateHypercertIPFSUrl = (cid: string) => {
+  return `https://${cid}.ipfs.w3s.link`;
+};
+
+export const generateEcocertainIPFSUrl = (cid: string) => {
   return `https://ipfs.io/ipfs/${cid}`;
 };
 
 export const getMetadata = async (cid: string) => {
-  const res = await fetch(generateIPFSUrl(cid));
+  const res = await fetch(generateHypercertIPFSUrl(cid));
   if (!res.ok) {
     throw new Error(`IPFS fetch failed: ${res.statusText}`);
   }


### PR DESCRIPTION
# Changes
Use the following ipfs gateways:
- For files pinned by hypercerts: w3s
- For files pinned by us (ecocertain): pinata

This fixes the Map not rendering problems.
<img width="542" alt="image" src="https://github.com/user-attachments/assets/909be15f-8e66-4600-99e9-d778b513ee33" />
