### PR TITLE
fix: use summation of sales to display the funding view on hypercert …

### DIFF
--- a/app/PriceFeedProvider.tsx
+++ b/app/PriceFeedProvider.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { RAW_TOKENS_CONFIG } from "@/config/raw-tokens";
+import getPriceFeed, { currencyAddressToSymbolMap } from "@/lib/pricefeed";
+import { useQuery } from "@tanstack/react-query";
+import { createContext, useContext, useState } from "react";
+
+type PriceFeedContextCatalog = {
+	loading: {
+		status: "loading";
+	};
+	error: {
+		status: "error";
+	};
+	ready: {
+		status: "ready";
+		toUSD: (currency: `0x${string}`, amount: number) => number | null;
+		fromUSD: (currency: `0x${string}`, amount: number) => number | null;
+	};
+};
+
+type PriceFeedContext = PriceFeedContextCatalog[keyof PriceFeedContextCatalog];
+
+const priceFeedContext = createContext<PriceFeedContext | null>(null);
+const currencies = Array.from(currencyAddressToSymbolMap.keys());
+
+export const PriceFeedProvider = ({
+	children,
+}: {
+	children: React.ReactNode;
+}) => {
+	const { data, isLoading, error } = useQuery({
+		queryKey: ["price-feed"],
+		queryFn: () => {
+			return Promise.all(currencies.map((c) => getPriceFeed(c)));
+		},
+	});
+
+	let providerValue: PriceFeedContext = {
+		status: "loading",
+	};
+
+	if (error) {
+		providerValue = {
+			status: "error",
+		};
+	} else if (isLoading) {
+		providerValue = {
+			status: "loading",
+		};
+	} else if (data === undefined) {
+		providerValue = {
+			status: "error",
+		};
+	} else {
+		providerValue = {
+			status: "ready",
+			toUSD: (currency, amount) => {
+				const currencyIndex = currencies.indexOf(currency);
+				if (currencyIndex === -1) {
+					return null;
+				}
+				// Find decimals for this currency
+				let decimals = 18; // default
+				for (const chainId in RAW_TOKENS_CONFIG) {
+					const token = RAW_TOKENS_CONFIG[chainId].find(
+						(t) => t.address.toLowerCase() === currency.toLowerCase(),
+					);
+					if (token) {
+						decimals = token.decimals;
+						break;
+					}
+				}
+				// amount is in raw units (wei), so convert to number of tokens
+				const amountInTokens = amount / 10 ** decimals;
+				const priceInUSD = data[currencyIndex].usdPrice;
+				return priceInUSD === null ? null : priceInUSD * amountInTokens;
+			},
+			fromUSD: (currency, amount) => {
+				const currencyIndex = currencies.indexOf(currency);
+				if (currencyIndex === -1) {
+					return null;
+				}
+				// Find decimals for this currency
+				let decimals = 18; // default
+				for (const chainId in RAW_TOKENS_CONFIG) {
+					const token = RAW_TOKENS_CONFIG[chainId].find(
+						(t) => t.address.toLowerCase() === currency.toLowerCase(),
+					);
+					if (token) {
+						decimals = token.decimals;
+						break;
+					}
+				}
+				const priceInUSD = data[currencyIndex].usdPrice;
+				if (priceInUSD === null) return null;
+				// amount is in USD, so convert to number of tokens, then to raw units
+				const amountInTokens = amount / priceInUSD;
+				return amountInTokens * 10 ** decimals;
+			},
+		};
+	}
+	return (
+		<priceFeedContext.Provider value={providerValue}>
+			{children}
+		</priceFeedContext.Provider>
+	);
+};
+
+const usePriceFeed = () => {
+	const context = useContext(priceFeedContext);
+	if (context === null) {
+		throw new Error("usePriceFeed must be used within a PriceFeedProvider");
+	}
+	return context;
+};
+
+export default usePriceFeed;

--- a/app/api/price-conversion/route.ts
+++ b/app/api/price-conversion/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+	const { searchParams } = new URL(request.url);
+	const id = searchParams.get("id");
+	const amount = searchParams.get("amount") || "1";
+	const convert_id = searchParams.get("convert_id") || "2781";
+
+	if (!id) {
+		return NextResponse.json(
+			{ error: "Missing id parameter" },
+			{ status: 400 },
+		);
+	}
+
+	const apiUrl = `https://api.coinmarketcap.com/data-api/v3/tools/price-conversion?amount=${encodeURIComponent(
+		amount,
+	)}&convert_id=${encodeURIComponent(convert_id)}&id=${encodeURIComponent(id)}`;
+
+	try {
+		const response = await fetch(apiUrl);
+		const data = await response.json();
+		return NextResponse.json(data);
+	} catch (error) {
+		return NextResponse.json(
+			{ error: "Failed to fetch price data", details: String(error) },
+			{ status: 500 },
+		);
+	}
+}

--- a/app/components/hypercerts-grid-view/card.tsx
+++ b/app/components/hypercerts-grid-view/card.tsx
@@ -106,10 +106,13 @@ const Card = ({
 								</div>
 								<CircularProgress
 									value={totalSalesInUSD / pricePerPercentInUSD}
-									text={`${Math.min(
-										Math.floor(totalSalesInUSD / pricePerPercentInUSD),
-										100,
-									).toFixed(0)}%`}
+									text={
+										Math.floor(totalSalesInUSD / pricePerPercentInUSD) > 999
+											? ">999%"
+											: `${Math.floor(
+													totalSalesInUSD / pricePerPercentInUSD,
+											  ).toFixed(0)}%`
+									}
 								/>
 							</div>
 						)

--- a/app/components/hypercerts-grid-view/card.tsx
+++ b/app/components/hypercerts-grid-view/card.tsx
@@ -1,18 +1,30 @@
+"use client";
+import usePriceFeed from "@/app/PriceFeedProvider";
 import type { Hypercert } from "@/app/graphql-queries/hypercerts";
+import CircularProgress from "@/components/ui/circular-progress";
 import { SUPPORTED_CHAINS } from "@/config/wagmi";
 import { calculateBigIntPercentage } from "@/lib/calculateBigIntPercentage";
 import { cn } from "@/lib/utils";
+import { Calendar } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { CircularProgressbar } from "react-circular-progressbar";
 import Progress from "../shared/progress";
 
 // * REFACTORED from hypercerts-app hypercert-window
-const Card = ({ hypercert }: { hypercert: Hypercert }) => {
+const Card = ({
+	hypercert,
+	totalSalesInUSD,
+}: {
+	hypercert: Hypercert;
+	totalSalesInUSD: number | null;
+}) => {
 	const {
 		hypercertId,
 		name,
 		description,
 		totalUnits,
+		sales,
 		unitsForSale,
 		pricePerPercentInUSD,
 		chainId,
@@ -23,6 +35,7 @@ const Card = ({ hypercert }: { hypercert: Hypercert }) => {
 		(x) => x.id === Number(chainId),
 	)?.name;
 	const percentAvailable = calculateBigIntPercentage(unitsForSale, totalUnits);
+
 	return (
 		<Link href={`/hypercert/${hypercertId}`} passHref>
 			<article className="group relative overflow-hidden rounded-2xl border border-border bg-muted">
@@ -36,11 +49,15 @@ const Card = ({ hypercert }: { hypercert: Hypercert }) => {
 					/>
 				</div>
 				<section className="absolute top-4 left-4 flex space-x-1 opacity-100 transition-opacity duration-150 ease-out group-hover:opacity-100 md:opacity-0">
-					<div className="rounded-md border border-white/60 bg-black px-2 py-0.5 text-white text-xs shadow-sm">
-						{chainName ?? "Unknown chain"}
-					</div>
-					<div className="rounded-md border border-black/60 bg-black px-2 py-0.5 text-white text-xs shadow-sm">
-						approved
+					<div className="flex items-center gap-1 rounded-md border border-black/60 bg-black px-2 py-0.5 text-white text-xs shadow-sm">
+						<Calendar size={12} />{" "}
+						{new Date(
+							Number(hypercert.creationBlockTimestamp) * 1000,
+						).toLocaleDateString("en-US", {
+							year: "numeric",
+							month: "short",
+							day: "numeric",
+						})}
 					</div>
 				</section>
 				<section
@@ -76,55 +93,26 @@ const Card = ({ hypercert }: { hypercert: Hypercert }) => {
 							</span>
 						</div>
 					) : (
-						<div className="flex items-center justify-between">
-							<div className="space-y-1">
-								<div className="font-semibold text-sm">
-									$
-									{Math.floor(
-										(100 - (percentAvailable ?? 0)) *
-											pricePerPercentInUSD *
-											100,
-									) / 100}{" "}
-									USD raised
+						totalSalesInUSD !== null && (
+							<div className="flex items-center justify-between">
+								<div className="space-y-1">
+									<div className="font-semibold text-sm">
+										${totalSalesInUSD.toFixed(0)} USD raised
+									</div>
+									<div className="text-muted-foreground text-sm">
+										${Math.floor(pricePerPercentInUSD * 100).toFixed(0)} target
+										· {buyerCount} buyer{buyerCount !== 1 ? "s" : ""}
+									</div>
 								</div>
-								<div className="text-muted-foreground text-sm">
-									${Math.floor(pricePerPercentInUSD * 100)} target ·{" "}
-									{buyerCount} buyer{buyerCount !== 1 ? "s" : ""}
-								</div>
+								<CircularProgress
+									value={totalSalesInUSD / pricePerPercentInUSD}
+									text={`${Math.min(
+										Math.floor(totalSalesInUSD / pricePerPercentInUSD),
+										100,
+									).toFixed(0)}%`}
+								/>
 							</div>
-							<div className="relative h-16 w-16">
-								<div className="absolute inset-0 flex items-center justify-center">
-									<span className="font-medium text-sm">
-										{Math.floor(100 - (percentAvailable ?? 0))}%
-									</span>
-								</div>
-								<svg
-									className="-rotate-90 h-full w-full"
-									aria-label="Progress Circle"
-								>
-									<title>Progress Circle</title>
-									<circle
-										className="stroke-muted"
-										strokeWidth="4"
-										fill="none"
-										r="28"
-										cx="32"
-										cy="32"
-									/>
-									<circle
-										className="stroke-primary"
-										strokeWidth="4"
-										fill="none"
-										r="28"
-										cx="32"
-										cy="32"
-										strokeDasharray={`${
-											((100 - (percentAvailable ?? 0)) * 175.93) / 100
-										} 175.93`}
-									/>
-								</svg>
-							</div>
-						</div>
+						)
 					)}
 				</section>
 			</article>

--- a/app/components/hypercerts-grid-view/card.tsx
+++ b/app/components/hypercerts-grid-view/card.tsx
@@ -97,7 +97,7 @@ const Card = ({
 							<div className="flex items-center justify-between">
 								<div className="space-y-1">
 									<div className="font-semibold text-sm">
-										${totalSalesInUSD.toFixed(0)} USD raised
+										${totalSalesInUSD.toFixed(0)} raised
 									</div>
 									<div className="text-muted-foreground text-sm">
 										${Math.floor(pricePerPercentInUSD * 100).toFixed(0)} target

--- a/app/components/hypercerts-grid-view/card.tsx
+++ b/app/components/hypercerts-grid-view/card.tsx
@@ -1,5 +1,3 @@
-"use client";
-import usePriceFeed from "@/app/PriceFeedProvider";
 import type { Hypercert } from "@/app/graphql-queries/hypercerts";
 import CircularProgress from "@/components/ui/circular-progress";
 import { SUPPORTED_CHAINS } from "@/config/wagmi";

--- a/app/components/hypercerts-grid-view/grid-view.tsx
+++ b/app/components/hypercerts-grid-view/grid-view.tsx
@@ -36,8 +36,8 @@ export function GridView({ hypercerts }: { hypercerts: Hypercert[] }) {
 	const searchInputState = useState("");
 	const [searchInput, setSearchInput] = searchInputState;
 	const sortOptionsState = useState<SortOption>({
-		key: "totalSales",
-		order: "desc",
+		key: "date",
+		order: "asc",
 	});
 	const [sortOptions, setSortOptions] = sortOptionsState;
 

--- a/app/components/hypercerts-grid-view/search.tsx
+++ b/app/components/hypercerts-grid-view/search.tsx
@@ -1,16 +1,31 @@
 import { Button } from "@/components/ui/button";
+import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { AnimatePresence, motion } from "framer-motion";
-import { Clock, Search as SearchIcon } from "lucide-react";
+import {
+	ArrowDown,
+	ArrowUp,
+	Clock,
+	Search as SearchIcon,
+	SortAsc,
+	SortDesc,
+} from "lucide-react";
 import type React from "react";
 
+export type SortKey = "date" | "price" | "totalSales";
 export type SortOption = {
-	key: "date";
+	key: SortKey;
 	order: "asc" | "desc";
 };
+
+const SORT_OPTIONS = [
+	{ value: "date", label: "By date created" },
+	{ value: "price", label: "By goal" },
+	{ value: "totalSales", label: "By fundings raised" },
+];
 
 const Search = ({
 	inputState,
@@ -18,12 +33,13 @@ const Search = ({
 }: {
 	inputState: [string, React.Dispatch<React.SetStateAction<string>>];
 	sortOptionsState: [
-		SortOption | null,
-		React.Dispatch<React.SetStateAction<SortOption | null>>,
+		SortOption,
+		React.Dispatch<React.SetStateAction<SortOption>>,
 	];
 }) => {
 	const [input, setInput] = inputState;
 	const [sortOptions, setSortOptions] = sortOptionsState;
+
 	return (
 		<div className="mb-4 flex w-full scale-100 flex-col items-center justify-center px-4">
 			<motion.div
@@ -66,29 +82,46 @@ const Search = ({
 					/>
 				</div>
 				<motion.div className="-mt-2 z-[5] w-full rounded-t-0 rounded-b-lg border border-border bg-background/80 p-1 pt-3">
-					<div className="flex items-center gap-2 px-2 py-1 font-sans">
-						<Label
-							className="text-muted-foreground"
-							htmlFor="latest-ecocerts-switch"
-						>
-							Order by recently created
-						</Label>
-						<Switch
-							className="scale-90"
-							id="latest-ecocerts-switch"
-							checked={Boolean(
-								sortOptions &&
-									sortOptions.key === "date" &&
-									sortOptions.order === "desc",
-							)}
-							onCheckedChange={(checked) => {
-								if (checked) {
-									setSortOptions({ key: "date", order: "desc" });
-								} else {
-									setSortOptions(null);
-								}
+					<div className="flex w-full items-center justify-between px-2 py-1 font-sans">
+						<Combobox
+							options={SORT_OPTIONS}
+							value={sortOptions.key}
+							onChange={(val) => {
+								setSortOptions({ ...sortOptions, key: val as SortKey });
 							}}
+							placeholder="Sort by..."
+							className="min-w-[160px]"
 						/>
+						<div className="flex flex-row overflow-hidden rounded-lg border border-border">
+							<Button
+								variant={sortOptions.order === "asc" ? "secondary" : "ghost"}
+								size="sm"
+								onClick={() => setSortOptions({ ...sortOptions, order: "asc" })}
+								className={`rounded-none border-b-2${
+									sortOptions.order === "asc"
+										? "border-primary"
+										: "border-transparent"
+								}`}
+								aria-pressed={sortOptions.order === "asc"}
+							>
+								<SortAsc className="h-4 w-4" />
+							</Button>
+							<Button
+								variant={sortOptions.order === "desc" ? "secondary" : "ghost"}
+								size="sm"
+								onClick={() =>
+									setSortOptions({ ...sortOptions, order: "desc" })
+								}
+								className={`rounded-none border-b-2${
+									sortOptions.order === "desc"
+										? "border-primary"
+										: "border-transparent"
+								}`}
+								aria-pressed={sortOptions.order === "desc"}
+							>
+								<SortDesc className="h-4 w-4" />
+							</Button>
+						</div>
 					</div>
 				</motion.div>
 			</motion.div>

--- a/app/components/hypercerts-grid-view/search.tsx
+++ b/app/components/hypercerts-grid-view/search.tsx
@@ -23,8 +23,8 @@ export type SortOption = {
 
 const SORT_OPTIONS = [
 	{ value: "date", label: "By date created" },
-	{ value: "price", label: "By goal" },
-	{ value: "totalSales", label: "By fundings raised" },
+	{ value: "totalSales", label: "By funds raised" },
+	{ value: "price", label: "By funding goal" },
 ];
 
 const Search = ({

--- a/app/components/hypercerts-grid-view/search.tsx
+++ b/app/components/hypercerts-grid-view/search.tsx
@@ -97,11 +97,12 @@ const Search = ({
 								variant={sortOptions.order === "asc" ? "secondary" : "ghost"}
 								size="sm"
 								onClick={() => setSortOptions({ ...sortOptions, order: "asc" })}
-								className={`rounded-none border-b-2${
+								className={cn(
+									"rounded-none border-b-2",
 									sortOptions.order === "asc"
 										? "border-primary"
-										: "border-transparent"
-								}`}
+										: "border-transparent",
+								)}
 								aria-pressed={sortOptions.order === "asc"}
 							>
 								<SortAsc className="h-4 w-4" />
@@ -112,11 +113,12 @@ const Search = ({
 								onClick={() =>
 									setSortOptions({ ...sortOptions, order: "desc" })
 								}
-								className={`rounded-none border-b-2${
+								className={cn(
+									"rounded-none border-b-2",
 									sortOptions.order === "desc"
 										? "border-primary"
-										: "border-transparent"
-								}`}
+										: "border-transparent",
+								)}
 								aria-pressed={sortOptions.order === "desc"}
 							>
 								<SortDesc className="h-4 w-4" />

--- a/app/components/shared/PageError.tsx
+++ b/app/components/shared/PageError.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { CircleAlert, Home, RotateCw } from "lucide-react";
 import Link from "next/link";

--- a/app/components/shared/progress.tsx
+++ b/app/components/shared/progress.tsx
@@ -25,6 +25,7 @@ const Progress = ({
 				animate={{ width: `${2 + (percentage / 100) * 99}%` }}
 				transition={{ duration: 0.5 }}
 			/>
+			{props.children}
 		</div>
 	);
 };

--- a/app/graphql-queries/hypercerts.ts
+++ b/app/graphql-queries/hypercerts.ts
@@ -137,7 +137,7 @@ export const fetchHypercertById = async (
 	const sales = hypercert.sales?.data ?? [];
 	const parsedSales = sales.map((sale) => {
 		return {
-			currency: sale.currency.toLowerCase(),
+			currency: sale.currency,
 			currencyAmount: typeCastApiResponseToBigInt(sale.currency_amount) ?? 0n,
 		};
 	});
@@ -387,7 +387,7 @@ export const fetchFullHypercertById = async (
 			price: typeCastApiResponseToBigInt(order.price) ?? 0n,
 			pricePerPercentInToken: Number(order.pricePerPercentInToken),
 			pricePerPercentInUSD: Number(order.pricePerPercentInUSD),
-			currency: order.currency.toLowerCase() as string,
+			currency: order.currency as string,
 			chainId: order.chainId as string,
 		};
 	});
@@ -396,8 +396,8 @@ export const fetchFullHypercertById = async (
 	const parsedSales = sales.map((sale) => {
 		return {
 			unitsBought: typeCastApiResponseToBigInt(sale.amounts?.[0] ?? 0) ?? 0n,
-			buyer: sale.buyer.toLowerCase(),
-			currency: sale.currency.toLowerCase(),
+			buyer: sale.buyer,
+			currency: sale.currency,
 			currencyAmount:
 				typeCastApiResponseToBigInt(sale.currency_amount ?? 0) ?? 0n,
 			creationBlockTimestamp:
@@ -448,7 +448,7 @@ export const fetchFullHypercertById = async (
 			creationBlockTimestamp: 1743699409n,
 			transactionHash:
 				"0xb596d456c3c84beb1d2d80f49b1898fae9511cd0eb7d420ba63a4868924f45c3",
-			currency: "0x471EcE3750Da237f93B8E339c536989b8978a438".toLowerCase(), // CELO,
+			currency: "0x471EcE3750Da237f93B8E339c536989b8978a438", // CELO,
 			currencyAmount: BigInt(2175 * 10 ** 18),
 		});
 	}

--- a/app/graphql-queries/hypercerts.ts
+++ b/app/graphql-queries/hypercerts.ts
@@ -83,6 +83,10 @@ export type Hypercert = {
 	name?: string;
 	description?: string;
 	totalUnits: bigint;
+	sales: {
+		currency: string;
+		currencyAmount: bigint; // in wei
+	}[];
 	unitsForSale?: bigint;
 	pricePerPercentInUSD?: number;
 	buyerCount: number;
@@ -128,6 +132,13 @@ export const fetchHypercertById = async (
 
 	const orderNonce = hypercert.orders?.data?.[0]?.orderNonce;
 
+	const sales = hypercert.sales?.data ?? [];
+	const parsedSales = sales.map((sale) => {
+		return {
+			currency: sale.currency.toLowerCase(),
+			currencyAmount: typeCastApiResponseToBigInt(sale.currency_amount) ?? 0n,
+		};
+	});
 	return {
 		hypercertId,
 		creatorAddress: hypercert.creator_address as string,
@@ -138,6 +149,7 @@ export const fetchHypercertById = async (
 		unitsForSale: typeCastApiResponseToBigInt(
 			hypercert.orders?.totalUnitsForSale,
 		),
+		sales: parsedSales,
 		pricePerPercentInUSD: pricePerPercentInUSDNumber,
 		buyerCount: uniqueBuyers.size,
 		creationBlockTimestamp:

--- a/app/graphql-queries/hypercerts.ts
+++ b/app/graphql-queries/hypercerts.ts
@@ -139,6 +139,19 @@ export const fetchHypercertById = async (
 			currencyAmount: typeCastApiResponseToBigInt(sale.currency_amount) ?? 0n,
 		};
 	});
+
+	// ADD UNINDEXED SALES:
+	if (
+		hypercertId ===
+			"42220-0x16bA53B74c234C870c61EFC04cD418B8f2865959-33347671958251969419410711528313284722688" ||
+		hypercertId ===
+			"42220-0x16bA53B74c234C870c61EFC04cD418B8f2865959-35389366159777600200190959172903893991424"
+	) {
+		parsedSales.push({
+			currency: "0x471EcE3750Da237f93B8E339c536989b8978a438", // CELO,
+			currencyAmount: BigInt(2175 * 10 ** 18),
+		});
+	}
 	return {
 		hypercertId,
 		creatorAddress: hypercert.creator_address as string,
@@ -419,6 +432,24 @@ export const fetchFullHypercertById = async (
 			};
 		})
 		.filter((attestation) => attestation !== null);
+
+	// ADD UNINDEXED SALES:
+	if (
+		hypercertId ===
+			"42220-0x16bA53B74c234C870c61EFC04cD418B8f2865959-33347671958251969419410711528313284722688" ||
+		hypercertId ===
+			"42220-0x16bA53B74c234C870c61EFC04cD418B8f2865959-35389366159777600200190959172903893991424"
+	) {
+		parsedSales.push({
+			unitsBought: 108750000000000000n,
+			buyer: "0xCe10d577295d34782815919843a3a4ef70Dc33ce",
+			creationBlockTimestamp: 1743699409n,
+			transactionHash:
+				"0xb596d456c3c84beb1d2d80f49b1898fae9511cd0eb7d420ba63a4868924f45c3",
+			currency: "0x471EcE3750Da237f93B8E339c536989b8978a438".toLowerCase(), // CELO,
+			currencyAmount: BigInt(2175 * 10 ** 18),
+		});
+	}
 
 	const fullHypercert = {
 		hypercertId,

--- a/app/graphql-queries/templates.ts
+++ b/app/graphql-queries/templates.ts
@@ -23,6 +23,8 @@ export const hypercert = `
         sales {
           data {
             buyer
+            currency
+            currency_amount
           }
         }
         hypercert_id

--- a/app/graphql-queries/user-hypercerts.ts
+++ b/app/graphql-queries/user-hypercerts.ts
@@ -62,6 +62,13 @@ export const fetchHypercertsByUserId = async (
 		);
 		const orderNonce = hypercert.orders?.data?.[0]?.orderNonce;
 
+		const sales = hypercert.sales?.data ?? [];
+		const parsedSales = sales.map((sale) => {
+			return {
+				currency: sale.currency.toLowerCase(),
+				currencyAmount: typeCastApiResponseToBigInt(sale.currency_amount) ?? 0n,
+			};
+		});
 		return {
 			hypercertId: hypercert.hypercert_id as string,
 			creatorAddress: hypercert.creator_address as string,
@@ -78,6 +85,7 @@ export const fetchHypercertsByUserId = async (
 				typeCastApiResponseToBigInt(hypercert.creation_block_timestamp) ?? 0n,
 			orderNonce: orderNonce ? Number(orderNonce) : undefined,
 			orderId: hypercert.orders?.data?.[0]?.id,
+			sales: parsedSales,
 		} satisfies Hypercert;
 	});
 

--- a/app/graphql-queries/user-hypercerts.ts
+++ b/app/graphql-queries/user-hypercerts.ts
@@ -65,7 +65,7 @@ export const fetchHypercertsByUserId = async (
 		const sales = hypercert.sales?.data ?? [];
 		const parsedSales = sales.map((sale) => {
 			return {
-				currency: sale.currency.toLowerCase(),
+				currency: sale.currency,
 				currencyAmount: typeCastApiResponseToBigInt(sale.currency_amount) ?? 0n,
 			};
 		});

--- a/app/hypercert/[hypercertId]/components/FundingView.tsx
+++ b/app/hypercert/[hypercertId]/components/FundingView.tsx
@@ -239,6 +239,7 @@ const VariantSelector = () => {
 	} = hypercert;
 	const { address } = useAccount();
 	const priceFeed = usePriceFeed();
+	console.log(hypercert);
 
 	// Calculate total sales in USD synchronously
 	const totalSalesInUSD = React.useMemo(() => {
@@ -249,7 +250,7 @@ const VariantSelector = () => {
 		for (const sale of sales) {
 			const usd = priceFeed.toUSD(
 				sale.currency as `0x${string}`,
-				Number(sale.currencyAmount),
+				BigInt(sale.currencyAmount),
 			);
 			if (usd !== null) {
 				total += usd;

--- a/app/hypercert/[hypercertId]/components/FundingView.tsx
+++ b/app/hypercert/[hypercertId]/components/FundingView.tsx
@@ -5,36 +5,116 @@ import Progress from "@/app/components/shared/progress";
 import useFullHypercert from "@/app/contexts/full-hypercert";
 import type { FullHypercert } from "@/app/graphql-queries/hypercerts";
 import { Button } from "@/components/ui/button";
+import QuickTooltip from "@/components/ui/quicktooltip";
 import { calculateBigIntPercentage } from "@/lib/calculateBigIntPercentage";
-import { formatDecimals } from "@/lib/utils";
+import { convertCurrencyPriceToUSD, formatDecimals } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, BadgeDollarSign, CircleAlert, Clock } from "lucide-react";
-import React from "react";
+import React, { useEffect } from "react";
 import { useAccount } from "wagmi";
 import PaymentFlow from "./PaymentFlow";
-const OpenVariant = ({ reached, goal }: { reached: number; goal: number }) => {
+
+const ProgressIndicator = ({
+	percentage,
+	tooltipText,
+	tooltipWidth,
+	direction,
+}: {
+	percentage: number;
+	tooltipText: string;
+	tooltipWidth?: number;
+	direction: "top" | "bottom";
+}) => {
 	return (
-		<div className="flex h-full w-full flex-col justify-between">
-			<div className="flex w-full flex-col">
-				<div className="relative z-[5] flex items-center justify-between">
-					<div className="flex flex-col items-start">
-						<span className="text-balance text-center text-muted-foreground">
-							Reached
-						</span>
-						<span className="font-bold text-xl">${reached}</span>
-					</div>
-					<div className="flex flex-col items-end">
-						<span className="text-balance text-center text-muted-foreground">
-							Goal
-						</span>
-						<span className="font-bold text-xl">${goal}</span>
+		<div
+			className={cn(
+				"relative mb-1 h-[12px] w-full",
+				direction === "top" ? "mb-1" : "mt-1",
+			)}
+		>
+			<div
+				className="-translate-x-1/2 absolute top-0 left-[-50%]"
+				style={{
+					left: `${percentage}%`,
+				}}
+			>
+				<div
+					className={cn(
+						"relative mx-auto h-0 w-0 scale-75 border-x-[8px] border-x-transparent transition-all duration-300 group-hover:scale-100",
+						direction === "top"
+							? "origin-bottom border-t-[12px] border-t-beige-muted-foreground"
+							: "origin-top border-b-[12px] border-b-primary/70",
+					)}
+				>
+					<div
+						className={cn(
+							"-translate-x-1/2 pointer-events-none absolute left-1/2 scale-0 rounded-full bg-background px-2 py-0.5 text-center font-bold text-sm opacity-0 shadow-md blur-xl transition-all duration-300 group-hover:scale-100 group-hover:opacity-100 group-hover:blur-none",
+							direction === "top"
+								? "bottom-[14px] mb-1 origin-bottom text-beige-muted-foreground"
+								: "top-[14px] mt-1 origin-top text-primary",
+						)}
+						style={{
+							width: tooltipWidth ? `${tooltipWidth}px` : undefined,
+						}}
+					>
+						{tooltipText}
 					</div>
 				</div>
-				<Progress
-					percentage={(reached * 100) / goal}
-					className="mt-2 bg-beige-muted"
-				/>
 			</div>
-			<div className="mt-4 flex items-center justify-end">
+		</div>
+	);
+};
+
+const OpenVariant = ({
+	totalSalesInUSD,
+	percentageUnitsSold,
+	goalInUSD,
+}: {
+	totalSalesInUSD: number;
+	percentageUnitsSold: number;
+	goalInUSD: number;
+}) => {
+	const goalPercentageOnBar =
+		totalSalesInUSD <= goalInUSD ? 100 : (goalInUSD / totalSalesInUSD) * 100;
+
+	return (
+		<div className="flex h-full w-full flex-col justify-between font-sans">
+			<div className="group flex w-full flex-col">
+				<div className="flex flex-col items-center">
+					<span className="font-bold text-3xl text-primary">
+						${totalSalesInUSD}
+					</span>
+					<span className="font-bold text-beige-muted-foreground text-xl">
+						out of ${goalInUSD}
+					</span>
+					<span className="font-bold text-muted-foreground text-sm">
+						sold so far.
+					</span>
+				</div>
+				<div className="mt-4 flex w-full flex-col items-center">
+					<div className="relative w-full">
+						<Progress
+							percentage={Math.min((totalSalesInUSD * 100) / goalInUSD, 100)}
+							className="h-6 rounded-sm bg-beige-muted"
+						/>
+						{goalPercentageOnBar < 99 && (
+							<div
+								className="-translate-x-[2px] absolute top-1 bottom-1 w-[4px] rounded-full bg-white shadow-md"
+								style={{
+									left: `${goalPercentageOnBar}%`,
+								}}
+							/>
+						)}
+					</div>
+					<ProgressIndicator
+						percentage={goalPercentageOnBar}
+						tooltipText={"Goal"}
+						direction="bottom"
+					/>
+				</div>
+			</div>
+			<div className="mt-2 flex items-center justify-end">
 				<PaymentFlow>
 					<Button className="gap-2" size={"sm"}>
 						Buy <ArrowRight size={16} />
@@ -105,8 +185,29 @@ const VariantSelector = () => {
 		totalUnits,
 		unitsForSale,
 		cheapestOrder: { pricePerPercentInUSD },
+		sales,
 	} = hypercert;
 	const { address } = useAccount();
+
+	const { data: totalSalesInUSD, isLoading } = useQuery({
+		queryKey: ["totalSalesInUSD", sales],
+		queryFn: async (): Promise<number> => {
+			if (!sales || sales.length === 0) return 0;
+			const salesInUSDPromises = sales.map(async (sale) => {
+				return convertCurrencyPriceToUSD(sale.currency, sale.currencyAmount);
+			});
+			const salesInUSD = await Promise.all(salesInUSDPromises);
+			let total = 0;
+			for (const sale of salesInUSD) {
+				if (sale !== null) {
+					total += sale;
+				}
+			}
+			return total;
+		},
+		enabled: pricePerPercentInUSD !== undefined && unitsForSale > 0n,
+	});
+
 	if (pricePerPercentInUSD === undefined) {
 		if (hypercert.creatorAddress.toLowerCase() === address?.toLowerCase()) {
 			return <ListingOptionVariant />;
@@ -117,10 +218,15 @@ const VariantSelector = () => {
 	const unitsSold = totalUnits - unitsForSale;
 	const percentCompleted = calculateBigIntPercentage(unitsSold, totalUnits);
 	if (percentCompleted === undefined) return <SoldVariant />;
+	if (isLoading || totalSalesInUSD === undefined) {
+		// Loading state, can show a spinner or just nothing
+		return null;
+	}
 	return (
 		<OpenVariant
-			reached={formatDecimals(percentCompleted * pricePerPercentInUSD)}
-			goal={formatDecimals(100 * pricePerPercentInUSD)}
+			percentageUnitsSold={percentCompleted}
+			goalInUSD={formatDecimals(100 * pricePerPercentInUSD)}
+			totalSalesInUSD={formatDecimals(totalSalesInUSD)}
 		/>
 	);
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import { config } from "@/config/wagmi";
 import { WagmiContextProvider } from "@/contexts/wagmi";
 import { Libre_Baskerville } from "next/font/google";
 import { headers } from "next/headers";
+import { PriceFeedProvider } from "./PriceFeedProvider";
 import FarcasterProvider from "./components/FarcasterProvider";
 import Footer from "./components/Footer";
 import Header from "./components/Header";
@@ -97,9 +98,11 @@ export default function RootLayout({
 				<FarcasterProvider>
 					<Analytics />
 					<WagmiContextProvider initialState={initialState}>
-						<Header />
-						<div className="flex-1">{children}</div>
-						<Footer />
+						<PriceFeedProvider>
+							<Header />
+							<div className="flex-1">{children}</div>
+							<Footer />
+						</PriceFeedProvider>
 					</WagmiContextProvider>
 				</FarcasterProvider>
 			</body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,10 @@ export default async function Home() {
 			<InfoBox>
 				<span className="text-base">🎉</span>
 				<p className="text-green-800 text-sm">
-					<b>Announcement:</b> Ecocertain rewards are starting on July 7th. <a href="https://gainforest.notion.site/Ecocertain-Rewards-Info-Page-21e94a2f76b3801582e9e84057ee16bc">Learn more.</a>
+					<b>Announcement:</b> Ecocertain rewards are starting on July 7th.{" "}
+					<a href="https://gainforest.notion.site/Ecocertain-Rewards-Info-Page-21e94a2f76b3801582e9e84057ee16bc">
+						Learn more.
+					</a>
 				</p>
 			</InfoBox>
 			<section className="flex flex-col items-center gap-4 p-8">

--- a/app/profile/[address]/components/content/created-hypercerts/card-options.tsx
+++ b/app/profile/[address]/components/content/created-hypercerts/card-options.tsx
@@ -8,6 +8,7 @@ import { ArrowRight, Trash2 } from "lucide-react";
 import React from "react";
 import { useAccount } from "wagmi";
 
+import CircularProgress from "@/components/ui/circular-progress";
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 import "react-circular-progressbar/dist/styles.css";
 
@@ -33,16 +34,7 @@ const CardOptions = () => {
 			{hasOrderListings ? (
 				<div className="flex items-center justify-between gap-2">
 					<div>
-						<CircularProgressbar
-							className="h-10 w-10"
-							styles={buildStyles({
-								pathColor: "hsl(var(--primary))",
-								textColor: "hsl(var(--foreground))",
-								textSize: "26px",
-							})}
-							text={`${Math.floor(100 - (percentAvailable ?? 0))}%`}
-							value={Math.floor(100 - (percentAvailable ?? 0))}
-						/>
+						<CircularProgress value={100 - (percentAvailable ?? 0)} />
 					</div>
 					<UnlistDialog hypercertId={hypercert.hypercertId}>
 						<Button variant={"secondary"} className="gap-2">

--- a/components/ui/circular-progress.tsx
+++ b/components/ui/circular-progress.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib/utils";
+import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
+
+const CircularProgress = ({
+	value,
+	className,
+	styles,
+	text,
+}: {
+	value: number;
+	className?: string;
+	styles?: React.CSSProperties;
+	text?: string;
+}) => {
+	return (
+		<div className="relative h-10 w-10">
+			<CircularProgressbar
+				className={cn("h-10 w-10", className)}
+				styles={buildStyles({
+					trailColor: "hsl(var(--muted))",
+					pathColor: "hsl(var(--primary))",
+					textColor: "hsl(var(--foreground))",
+					textSize: "26px",
+					...styles,
+				})}
+				value={value}
+			/>
+			{text !== undefined && (
+				<div className="absolute inset-0 flex items-center justify-center">
+					<span className="font-medium text-[0.6rem]">{text}</span>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default CircularProgress;

--- a/config/wagmi.ts
+++ b/config/wagmi.ts
@@ -37,11 +37,11 @@ const normalizeTokensConfig = (
       return [
         chainId,
         tokens.map((token) => {
-          const address = token.address.toLowerCase() as `0x${string}`;
+          const address = token.address as `0x${string}`;
           const isUSDPegged = token.isUSDPegged ?? true;
           return {
             ...token,
-            address: token.address.toLowerCase(),
+            address: token.address,
             usdPriceFetcher:
               token.usdPriceFetcher ?? isUSDPegged
                 ? getUSDPeggedValue

--- a/lib/pricefeed.ts
+++ b/lib/pricefeed.ts
@@ -3,63 +3,67 @@ import { RAW_TOKENS_CONFIG } from "@/config/raw-tokens";
 const symbolToCurrencyAddressMap = new Map<string, `0x${string}`>();
 
 for (const chainId in RAW_TOKENS_CONFIG) {
-	const tokens = RAW_TOKENS_CONFIG[chainId];
-	for (const token of tokens) {
-		symbolToCurrencyAddressMap.set(
-			token.symbol,
-			token.address.toLowerCase() as `0x${string}`,
-		);
-	}
+  const tokens = RAW_TOKENS_CONFIG[chainId];
+  for (const token of tokens) {
+    symbolToCurrencyAddressMap.set(
+      token.symbol,
+      token.address.toLowerCase() as `0x${string}`
+    );
+  }
 }
 
 const currencyAddressToSymbolMap = new Map<`0x${string}`, string>();
 symbolToCurrencyAddressMap.forEach((value, key) => {
-	currencyAddressToSymbolMap.set(value, key);
+  currencyAddressToSymbolMap.set(value, key);
 });
 
 const currencyAddressToPriceFeedIdMap = new Map<string, number>([
-	[symbolToCurrencyAddressMap.get("CELO") ?? "", 5567],
+  [symbolToCurrencyAddressMap.get("CELO") ?? "", 5567],
 ]);
 
 type ApiResponse<Symbol extends string> = {
-	status: {
-		timestamp: string;
-		error_code: number;
-		error_message: unknown | "SUCCESS";
-		elapsed: string;
-		credit_count: number;
-	};
-	data?: {
-		symbol: Symbol;
-		id: string;
-		name: string;
-		amount: number;
-		last_updated: number;
-		quote: {
-			cryptoId: number;
-			symbol: string;
-			price: number;
-			lastUpdated: number;
-		}[];
-	};
+  status: {
+    timestamp: string;
+    error_code: number;
+    error_message: unknown | "SUCCESS";
+    elapsed: string;
+    credit_count: number;
+  };
+  data?: {
+    symbol: Symbol;
+    id: string;
+    name: string;
+    amount: number;
+    last_updated: number;
+    quote: {
+      cryptoId: number;
+      symbol: string;
+      price: number;
+      lastUpdated: number;
+    }[];
+  };
 };
 
 const getPriceFeed = async (currencyAddress: `0x${string}`) => {
-	const normalizedCurrencyAddress =
-		currencyAddress.toLowerCase() as `0x${string}`;
-	const priceFeedId = currencyAddressToPriceFeedIdMap.get(
-		normalizedCurrencyAddress,
-	);
-	const symbol = currencyAddressToSymbolMap.get(normalizedCurrencyAddress);
-	if (!priceFeedId || !symbol) {
-		return { usdPrice: null };
-	}
+  const normalizedCurrencyAddress =
+    currencyAddress.toLowerCase() as `0x${string}`;
+  const priceFeedId = currencyAddressToPriceFeedIdMap.get(
+    normalizedCurrencyAddress
+  );
+  const symbol = currencyAddressToSymbolMap.get(normalizedCurrencyAddress);
+  if (!priceFeedId || !symbol) {
+    return { usdPrice: null };
+  }
 
-	const response = await fetch(
-		`https://api.coinmarketcap.com/data-api/v3/tools/price-conversion?amount=1&convert_id=2781&id=${priceFeedId}`,
-	);
-	const data: ApiResponse<typeof symbol> = await response.json();
-	return { usdPrice: data?.data?.quote[0]?.price ?? null };
+  let priceFeedApiUrl = `https://api.coinmarketcap.com/data-api/v3/tools/price-conversion?amount=1&convert_id=2781&id=${priceFeedId}`;
+
+  if (typeof window !== "undefined") {
+    priceFeedApiUrl = `/api/price-conversion?id=${priceFeedId}&amount=1&convert_id=2781`;
+  }
+
+  const response = await fetch(priceFeedApiUrl);
+  const data: ApiResponse<typeof symbol> = await response.json();
+  return { usdPrice: data?.data?.quote[0]?.price ?? null };
 };
 
 export default getPriceFeed;

--- a/lib/pricefeed.ts
+++ b/lib/pricefeed.ts
@@ -7,7 +7,7 @@ for (const chainId in RAW_TOKENS_CONFIG) {
   for (const token of tokens) {
     symbolToCurrencyAddressMap.set(
       token.symbol,
-      token.address.toLowerCase() as `0x${string}`
+      token.address as `0x${string}`
     );
   }
 }
@@ -47,8 +47,7 @@ type ApiResponse<Symbol extends string> = {
 };
 
 const getPriceFeed = async (currencyAddress: `0x${string}`) => {
-  const normalizedCurrencyAddress =
-    currencyAddress.toLowerCase() as `0x${string}`;
+  const normalizedCurrencyAddress = currencyAddress as `0x${string}`;
   const priceFeedId = currencyAddressToPriceFeedIdMap.get(
     normalizedCurrencyAddress
   );

--- a/lib/pricefeed.ts
+++ b/lib/pricefeed.ts
@@ -17,6 +17,8 @@ symbolToCurrencyAddressMap.forEach((value, key) => {
   currencyAddressToSymbolMap.set(value, key);
 });
 
+export { currencyAddressToSymbolMap };
+
 const currencyAddressToPriceFeedIdMap = new Map<string, number>([
   [symbolToCurrencyAddressMap.get("CELO") ?? "", 5567],
 ]);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,140 +4,138 @@ import { twMerge } from "tailwind-merge";
 import type { Address } from "viem";
 
 const BASE_URL =
-	process.env.NODE_ENV === "production"
-		? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-		: "http://localhost:3000";
+  process.env.NODE_ENV === "production"
+    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+    : "http://localhost:3000";
 
 const INCLUDES_FORWARD_SLASH_AT_START_REGEX = /^\/(.|\n)*$/;
 const INCLUDES_FORWARD_SLASH_AT_START = (string: string) =>
-	INCLUDES_FORWARD_SLASH_AT_START_REGEX.test(string);
+  INCLUDES_FORWARD_SLASH_AT_START_REGEX.test(string);
 
 export const getUrl = (path: string) =>
-	`${BASE_URL}${!INCLUDES_FORWARD_SLASH_AT_START(path) ? "/" : ""}${path}`;
+  `${BASE_URL}${!INCLUDES_FORWARD_SLASH_AT_START(path) ? "/" : ""}${path}`;
 
 export function cn(...inputs: ClassValue[]) {
-	return twMerge(clsx(inputs));
+  return twMerge(clsx(inputs));
 }
 
 export function formatDate(d: Date) {
-	const date = new Date(Number(d) * 1000);
-	return date
-		.toLocaleDateString("en-US", {
-			year: "numeric",
-			month: "short", // "Oct"
-			day: "numeric",
-		})
-		.toUpperCase();
+  const date = new Date(Number(d) * 1000);
+  return date
+    .toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short", // "Oct"
+      day: "numeric",
+    })
+    .toUpperCase();
 }
 
 export const formatCurrency = (value: number, currencyCode = "USD") => {
-	return new Intl.NumberFormat("en-US", {
-		style: "currency",
-		currency: currencyCode,
-		minimumFractionDigits: 2,
-	}).format(value);
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currencyCode,
+    minimumFractionDigits: 2,
+  }).format(value);
 };
 
 export const truncateEthereumAddress = (
-	address: `0x${string}`,
-	length = 4,
+  address: `0x${string}`,
+  length = 4
 ): string => {
-	if (!address) {
-		return "";
-	}
-	if (address.length <= 2 + length * 2) {
-		return address;
-	}
-	return `${address.substring(0, length + 2)}...${address.substring(
-		address.length - length,
-	)}`;
+  if (!address) {
+    return "";
+  }
+  if (address.length <= 2 + length * 2) {
+    return address;
+  }
+  return `${address.substring(0, length + 2)}...${address.substring(
+    address.length - length
+  )}`;
 };
 
 export const isNotNull = <T>(value: T | null): value is T => {
-	return value !== null;
+  return value !== null;
 };
 
 export const delay = (ms: number) =>
-	new Promise((resolve) => setTimeout(resolve, ms));
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 export const isValidEthereumAddress = (address: string) =>
-	/^0x[a-fA-F0-9]{40}$/.test(address);
+  /^0x[a-fA-F0-9]{40}$/.test(address);
 
 export function typeCastApiResponseToBigInt(
-	value: unknown,
+  value: unknown
 ): bigint | undefined {
-	if (value === undefined || value === null) {
-		return undefined;
-	}
-	if (
-		typeof value === "string" ||
-		typeof value === "number" ||
-		typeof value === "bigint"
-	) {
-		return BigInt(value);
-	}
-	return undefined;
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "bigint"
+  ) {
+    return BigInt(value);
+  }
+  return undefined;
 }
 
 export function bigintToFormattedDate(timestamp: bigint): string {
-	// Convert bigint to number
-	const milliseconds = Number(timestamp) * 1000;
-	const date = new Date(milliseconds);
+  // Convert bigint to number
+  const milliseconds = Number(timestamp) * 1000;
+  const date = new Date(milliseconds);
 
-	// Define options for formatting
-	const options: Intl.DateTimeFormatOptions = {
-		day: "2-digit",
-		month: "short",
-		year: "numeric",
-	};
+  // Define options for formatting
+  const options: Intl.DateTimeFormatOptions = {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  };
 
-	// Format the date using toLocaleDateString
-	return date.toLocaleDateString("en-GB", options);
+  // Format the date using toLocaleDateString
+  return date.toLocaleDateString("en-GB", options);
 }
 
-// ❗❗❗ Use the `currency` param in the following function get the latest price data.
-// ❗❗❗ Using 1USD for now, because the currency is USD pegged for now.
 export const convertCurrencyPriceToUSD = async (
-	currency: string,
-	tokens: bigint,
+  currency: string,
+  tokens: bigint
 ): Promise<null | number> => {
-	const weiFactor = BigInt(10 ** 18);
-	const precision = 4;
-	const precisionMultiplier = BigInt(10 ** precision);
+  const weiFactor = BigInt(10 ** 18);
+  const precision = 4;
+  const precisionMultiplier = BigInt(10 ** precision);
 
-	const tokensInNumber =
-		Number((tokens * precisionMultiplier) / weiFactor) /
-		Number(precisionMultiplier);
+  const tokensInNumber =
+    Number((tokens * precisionMultiplier) / weiFactor) /
+    Number(precisionMultiplier);
 
-	const currencyDetails = currencyMap[currency.toLowerCase() as `0x${string}`];
-	if (currencyDetails) {
-		const pricePerToken = await currencyDetails.usdPriceFetcher();
-		return tokensInNumber * pricePerToken;
-	}
-	return null;
+  const currencyDetails = currencyMap[currency as `0x${string}`];
+  if (currencyDetails) {
+    const pricePerToken = await currencyDetails.usdPriceFetcher();
+    return tokensInNumber * pricePerToken;
+  }
+  return null;
 };
 
 export const formatDecimals = (value: number, maxDecimals?: number) => {
-	maxDecimals = maxDecimals ?? 2;
-	return Math.floor(value * 10 ** maxDecimals) / 10 ** maxDecimals;
+  maxDecimals = maxDecimals ?? 2;
+  return Math.floor(value * 10 ** maxDecimals) / 10 ** maxDecimals;
 };
 
 export const getValueFromSearchParams = <T extends string>(
-	searchParams: { [key: string]: string | string[] | undefined },
-	key: string,
-	defaultValue: T,
-	validValues: T[],
+  searchParams: { [key: string]: string | string[] | undefined },
+  key: string,
+  defaultValue: T,
+  validValues: T[]
 ): T => {
-	if (key in searchParams) {
-		if (typeof searchParams[key] === "string") {
-			if (validValues.includes(searchParams[key] as T))
-				return searchParams[key] as T;
-		}
-		if (Array.isArray(searchParams[key])) {
-			for (const value of searchParams[key]) {
-				if (validValues.includes(value as T)) return value as T;
-			}
-		}
-	}
-	return defaultValue;
+  if (key in searchParams) {
+    if (typeof searchParams[key] === "string") {
+      if (validValues.includes(searchParams[key] as T))
+        return searchParams[key] as T;
+    }
+    if (Array.isArray(searchParams[key])) {
+      for (const value of searchParams[key]) {
+        if (validValues.includes(value as T)) return value as T;
+      }
+    }
+  }
+  return defaultValue;
 };


### PR DESCRIPTION
# Changes
1. Update the funding view logic to use the summation of total sales.
2. Update the cards to use the same summation logic for calculation total sales.
3. Add more sorting options on the homepage.
4. Hardcode two unindexed sales (Climatica and Oceanus)

# Screenshots
<img width="489" alt="image" src="https://github.com/user-attachments/assets/816f46fa-3564-4679-a8f7-fad75fe62bd8" />
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/17a48122-c710-4e6f-8174-52114158a06d" />

