### PR TITLE
update Proofs of Impact code to adjust for changes in api v2

### DIFF
--- a/graphql/hypercerts/queries/hypercerts.ts
+++ b/graphql/hypercerts/queries/hypercerts.ts
@@ -393,7 +393,7 @@ export const fetchFullHypercertById = async (
   const parsedAttestations = attestations
     .map((attestation) => {
       if (
-        attestation.schema_uid !==
+        attestation.eas_schema.uid !==
         "0x48e3e1be1e08084b408a7035ac889f2a840b440bbf10758d14fb722831a200c3"
       )
         return null;


### PR DESCRIPTION
# Changes
1. Update the code related to eas attestations (in proof of impact section), to adjust for the changes in the new hypercerts api (v2).

# Notes
When using API v1, all the attestations that were made on Celo chain, were being returned as if they were created on chain 11155111 (Sepolia). So, API v2 migration was important to at least get the chain info right. But due to some other changes in the object structure, the filtering of eas attestations by schema id was failing - resulting in no attestations / proofs of impact being displayed in the UI.

# Screenshot
<img width="1305" height="790" alt="image" src="https://github.com/user-attachments/assets/4943ec8b-aae5-423b-b4b7-5af2e37cca9e" />
