### PR TITLE
fix: update banner for celo support streams

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,22 +11,22 @@ export default async function Home() {
 	return (
 		<main className="flex flex-col gap-4 pt-4 pb-[64px] md:pb-0">
 			<div className="flex items-center justify-center">
-				<InfoBox variant="warning" className="max-w-4xl">
-					<span className="text-base">⚠️</span>
+				<InfoBox variant="success" className="max-w-4xl">
+					{/* <span className="text-base">⚠️</span>
 					<p className="text-sm">
 						<b>Service notice:</b> Stablecoin purchases on Ecocertain are down.
 						We're working on a fix.
+					</p> */}
+					<span className="text-base">🎉</span>
+					<p className="text-green-800 text-sm">
+						<b>Announcement:</b> Ecocertain rewards started on July 7th!{" "}
+						<a
+							href="https://gainforest.notion.site/Ecocertain-Rewards-Info-Page-21e94a2f76b3801582e9e84057ee16bc"
+							className="underline"
+						>
+							Learn more.
+						</a>
 					</p>
-					{/* <span className="text-base">🎉</span>
-				<p className="text-green-800 text-sm">
-					<b>Announcement:</b> Ecocertain rewards started on July 7th!{" "}
-					<a
-						href="https://gainforest.notion.site/Ecocertain-Rewards-Info-Page-21e94a2f76b3801582e9e84057ee16bc"
-						className="underline"
-					>
-						Learn more.
-					</a>
-				</p> */}
 				</InfoBox>
 			</div>
 			<section className="flex flex-col items-center gap-4 p-8">


### PR DESCRIPTION
# Changes
There are no more bugs related to stablecoin purhcases (fixed in previous continuous PRs), so update the banner to declare to the users that the Celo Support streams started on 7th July and is still in progress.

# Screenshot
<img width="1319" height="209" alt="image" src="https://github.com/user-attachments/assets/2ac514e6-cfa5-4e43-8fdd-36ac37d02fcd" />
