### PR TITLE
update USDT address, and use hypercert defined currencies

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import { cn } from "@/lib/utils";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import "vaul/dist/index.css";
 import "./globals.css";
 
 import { Analytics } from "@vercel/analytics/react";

--- a/config/raw-tokens.ts
+++ b/config/raw-tokens.ts
@@ -41,7 +41,7 @@ export const RAW_TOKENS_CONFIG: TokensConfig<"raw"> = {
     },
     {
       symbol: "USDT",
-      address: "0xb020D981420744F6b0FedD22bB67cd37Ce18a1d5",
+      address: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
       decimals: 6,
     },
     {


### PR DESCRIPTION
# Changes
- Fixed the address of USDT on Celo. Earlier no sales on USDT on Celo were being displayed in the sales section of the hypercert, because we were filtering with the wrong address. Now its fixed.
- Rather than relying on a currencies config, the sales section now uses the hypercerts sdk to access al the currencies supported by the platform in Celo, and display them. This leaves no room for errrors.

# Screenshot
<img width="641" height="411" alt="image" src="https://github.com/user-attachments/assets/fec38588-77c6-4365-8d74-c10a4d2afb9d" />
