### PR TITLE
Fix Purchase Flow Failing Transactions

### DIFF
--- a/app/hypercert/[hypercertId]/components/PurchaseFlow/payment-progress/store.ts
+++ b/app/hypercert/[hypercertId]/components/PurchaseFlow/payment-progress/store.ts
@@ -49,16 +49,22 @@ export const PAYMENT_PROGRESS_STEPS: Step[] = [
 		index: 2,
 	},
 	{
+		title: "Waiting for approval",
+		description: "Please wait while the approval is confirmed...",
+		Icon: Hourglass,
+		index: 3,
+	},
+	{
 		title: "Sign the transaction",
 		description: "Waiting for you to sign the transaction...",
 		Icon: BadgeDollarSign,
-		index: 3,
+		index: 4,
 	},
 	{
 		title: "Waiting for confirmation",
 		description: "Please wait while the transaction is confirmed...",
 		Icon: Hourglass,
-		index: 4,
+		index: 5,
 	},
 	{
 		title: "Pay the platform fee",
@@ -66,13 +72,13 @@ export const PAYMENT_PROGRESS_STEPS: Step[] = [
 			GAINFOREST_TIP_AMOUNT,
 		)} CELO...`,
 		Icon: FileSignature,
-		index: 5,
+		index: 6,
 	},
 	{
 		title: "Order completed...",
 		description: "Your order has been completed successfully...",
 		Icon: CheckCircle,
-		index: 6,
+		index: 7,
 	},
 ];
 
@@ -138,14 +144,13 @@ const usePaymentProgressStore = create<
 			errorTitle = "Approval not confirmed";
 			errorDescription = "The spending cap could not be approved.";
 			// We approve more than we need to avoid issues with some arithmetics while executing the order
-			const tokensToApproveInWei = (unitsToBuy + 100n) * BigInt(order.price);
-			const [, approveTxError] = await tryCatch(() =>
+			const tokensToApproveInWei = unitsToBuy * BigInt(order.price);
+			const [approveTx, approveTxError] = await tryCatch(() =>
 				hcExchangeClient.approveErc20(
 					order.currency as `0x${string}`,
 					tokensToApproveInWei,
 				),
 			);
-			console.log(unitsToBuy, order.price);
 			if (approveTxError) {
 				set({
 					status: "error",
@@ -157,6 +162,28 @@ const usePaymentProgressStore = create<
 
 			// =========== STEP 3
 			set({ currentStepIndex: 3 });
+			const [approveTxReceipt, approveTxReceiptError] = await tryCatch(() =>
+				approveTx.wait(),
+			);
+			if (approveTxReceiptError) {
+				set({
+					status: "error",
+					errorState: { title: errorTitle, description: errorDescription },
+				});
+				console.error("Error getting approval receipt:", approveTxReceiptError);
+				return;
+			}
+			if (approveTxReceipt?.status !== 1) {
+				set({
+					status: "error",
+					errorState: { title: errorTitle, description: errorDescription },
+				});
+				console.error("Error approving spending cap:", approveTxReceipt);
+				return;
+			}
+
+			// =========== STEP 4
+			set({ currentStepIndex: 4 });
 			errorTitle = "Transaction rejected";
 			errorDescription = "The transaction was rejected.";
 			const takerOrder = hcExchangeClient.createFractionalSaleTakerBid(
@@ -165,11 +192,10 @@ const usePaymentProgressStore = create<
 				unitsToBuy, // Number of units to buy.
 				order.price, // Price per unit, in wei.
 			);
-			const tokensToPayInWei = unitsToBuy * BigInt(order.price);
 			const overrides =
 				order.currency === "0x0000000000000000000000000000000000000000"
 					? {
-							value: tokensToPayInWei,
+							value: tokensToApproveInWei,
 					  }
 					: undefined;
 			const [executeTx, executeTxError] = await tryCatch(() =>
@@ -196,8 +222,8 @@ const usePaymentProgressStore = create<
 				return;
 			}
 
-			// =========== STEP 4
-			set({ currentStepIndex: 4 });
+			// =========== STEP 5
+			set({ currentStepIndex: 5 });
 			errorTitle = "Transaction not confirmed";
 			errorDescription = "The transaction could not be confirmed.";
 			const [receipt, receiptError] = await tryCatch(() => executeTx.wait());
@@ -210,8 +236,8 @@ const usePaymentProgressStore = create<
 				return;
 			}
 
-			// =========== STEP 5
-			set({ currentStepIndex: 5 });
+			// =========== STEP 6
+			set({ currentStepIndex: 6 });
 			const [, tipTxError] = await tryCatch(async () => {
 				const walletClient = createWalletClient({
 					chain: celo,
@@ -238,8 +264,8 @@ const usePaymentProgressStore = create<
 				console.error("Tipping error:", tipTxError);
 			}
 
-			// =========== STEP 6
-			set({ currentStepIndex: 6 });
+			// =========== STEP 7
+			set({ currentStepIndex: 7 });
 			set({ status: "success" });
 		},
 		reset: () => {

--- a/app/hypercert/[hypercertId]/components/PurchaseFlow/payment-progress/store.ts
+++ b/app/hypercert/[hypercertId]/components/PurchaseFlow/payment-progress/store.ts
@@ -137,11 +137,12 @@ const usePaymentProgressStore = create<
 			set({ currentStepIndex: 2 });
 			errorTitle = "Approval not confirmed";
 			errorDescription = "The spending cap could not be approved.";
-			const tokensToPayInWei = unitsToBuy * BigInt(order.price);
+			// We approve more than we need to avoid issues with some arithmetics while executing the order
+			const tokensToApproveInWei = (unitsToBuy + 100n) * BigInt(order.price);
 			const [, approveTxError] = await tryCatch(() =>
 				hcExchangeClient.approveErc20(
 					order.currency as `0x${string}`,
-					tokensToPayInWei,
+					tokensToApproveInWei,
 				),
 			);
 			console.log(unitsToBuy, order.price);
@@ -164,6 +165,7 @@ const usePaymentProgressStore = create<
 				unitsToBuy, // Number of units to buy.
 				order.price, // Price per unit, in wei.
 			);
+			const tokensToPayInWei = unitsToBuy * BigInt(order.price);
 			const overrides =
 				order.currency === "0x0000000000000000000000000000000000000000"
 					? {


### PR DESCRIPTION
# Changes
1. Wait for the "Approval Transaction" to finish before calling the actual purchase flow transaction. Not finishing of the first transaction was the reason of failure of the subsequent one.