### PR TITLE
fix: remove target blanks from hypercert cards on profile page

### DIFF
--- a/app/profile/[address]/components/content/created-hypercerts/card.tsx
+++ b/app/profile/[address]/components/content/created-hypercerts/card.tsx
@@ -23,9 +23,9 @@ export default function Card({ hypercert }: { hypercert: Hypercert }) {
 					/>
 					{hypercertId !== undefined && (
 						<div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100">
-							<Link href={`/hypercert/${hypercertId}`} target="_blank" passHref>
+							<Link href={`/hypercert/${hypercertId}`}>
 								<Button variant={"secondary"} className="gap-2">
-									View Hypercert <ArrowUpRight size={20} />
+									View Hypercert
 								</Button>
 							</Link>
 						</div>

--- a/app/profile/[address]/components/content/supported-hypercerts/card.tsx
+++ b/app/profile/[address]/components/content/supported-hypercerts/card.tsx
@@ -30,15 +30,14 @@ export default function Card({ combinedSale }: { combinedSale: CombinedSale }) {
 					width={200}
 					className="h-auto w-full transition group-hover:scale-[1.05] group-hover:blur-sm group-hover:brightness-75"
 				/>
-				{hypercertId !== undefined && (
-					<div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100">
-						<Link href={`/hypercert/${hypercertId}`}>
-							<Button variant={"secondary"} className="gap-2">
-								View Hypercert <ArrowRight size={20} />
-							</Button>
-						</Link>
-					</div>
-				)}
+
+				<div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100">
+					<Link href={`/hypercert/${hypercertId}`}>
+						<Button variant={"secondary"} className="gap-2">
+							View Hypercert
+						</Button>
+					</Link>
+				</div>
 			</div>
 			<section
 				className="w-full flex-1 space-y-2 border-t border-t-border bg-background/90 p-4 backdrop-blur-md"


### PR DESCRIPTION
# Changes
1. Remove target blainks from cards on the profile page to make the hypercerts open in the same tab.
2. Remove the arrow up right icon that indicated the opening in new tab.

# Screenshots
<img width="815" height="468" alt="image" src="https://github.com/user-attachments/assets/5228ceb0-dd74-450b-855d-93542543409e" />
