### PR TITLE
fix: fix tip transactions failing due to divvi

### DIFF
--- a/app/components/create-listing-dialog/listing-progress.tsx
+++ b/app/components/create-listing-dialog/listing-progress.tsx
@@ -24,7 +24,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import React, { useEffect, useRef, useState } from "react";
-import { createWalletClient, custom, formatEther } from "viem";
+import { createWalletClient, custom, erc20Abi, formatEther } from "viem";
 import { celo } from "viem/chains";
 import { useAccount, usePublicClient } from "wagmi";
 
@@ -309,11 +309,13 @@ const ListingProgress = ({
 				),
 			});
 			const [account] = await walletClient.getAddresses();
-			const txhash = await walletClient.sendTransaction({
+			const txhash = await walletClient.writeContract({
 				account,
-				to: GAINFOREST_TIP_ADDRESS,
-				value: GAINFOREST_TIP_AMOUNT,
-				data: `0x${DIVVI_DATA_SUFFIX}`,
+				address: "0x471EcE3750Da237f93B8E339c536989b8978a438", // Celo CELO token address
+				abi: erc20Abi,
+				functionName: "transfer",
+				args: [GAINFOREST_TIP_ADDRESS, GAINFOREST_TIP_AMOUNT],
+				dataSuffix: `0x${DIVVI_DATA_SUFFIX}`,
 			});
 
 			if (txhash) {

--- a/app/hypercert/[hypercertId]/components/PurchaseFlow/payment-progress/store.ts
+++ b/app/hypercert/[hypercertId]/components/PurchaseFlow/payment-progress/store.ts
@@ -17,7 +17,7 @@ import {
 	Loader2,
 	type LucideProps,
 } from "lucide-react";
-import { createWalletClient, custom, formatEther } from "viem";
+import { createWalletClient, custom, erc20Abi, formatEther } from "viem";
 import { celo } from "viem/chains";
 import { create } from "zustand";
 
@@ -247,11 +247,13 @@ const usePaymentProgressStore = create<
 					),
 				});
 				const [account] = await walletClient.getAddresses();
-				const txhash = await walletClient.sendTransaction({
+				const txhash = await walletClient.writeContract({
 					account,
-					to: GAINFOREST_TIP_ADDRESS,
-					value: GAINFOREST_TIP_AMOUNT,
-					data: `0x${DIVVI_DATA_SUFFIX}`,
+					address: "0x471EcE3750Da237f93B8E339c536989b8978a438", // Celo CELO token address
+					abi: erc20Abi,
+					functionName: "transfer",
+					args: [GAINFOREST_TIP_ADDRESS, GAINFOREST_TIP_AMOUNT],
+					dataSuffix: `0x${DIVVI_DATA_SUFFIX}`,
 				});
 				// We don't wait for confirmation as per requirements
 				submitReferral({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,12 +11,12 @@ export default async function Home() {
 	return (
 		<main className="flex flex-col gap-4 pt-4 pb-[64px] md:pb-0">
 			<div className="flex items-center justify-center">
-				<InfoBox variant="success" className="max-w-4xl">
-					{/* <span className="text-base">⚠️</span>
+				{/* <InfoBox variant="success" className="max-w-4xl">
+					<span className="text-base">⚠️</span>
 					<p className="text-sm">
 						<b>Service notice:</b> Stablecoin purchases on Ecocertain are down.
 						We're working on a fix.
-					</p> */}
+					</p>
 					<span className="text-base">🎉</span>
 					<p className="text-green-800 text-sm">
 						<b>Announcement:</b> Ecocertain Reward Round 0 has ended! Payouts
@@ -28,7 +28,7 @@ export default async function Home() {
 							Learn more.
 						</a>
 					</p>
-				</InfoBox>
+				</InfoBox> */}
 			</div>
 			<section className="flex flex-col items-center gap-4 p-8">
 				<div className="flex w-full flex-col items-center px-4">

--- a/app/submit/components/minting-progress-dialog/minting-progress.tsx
+++ b/app/submit/components/minting-progress-dialog/minting-progress.tsx
@@ -25,7 +25,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import React, { useEffect, useRef, useState } from "react";
-import { createWalletClient, custom, formatEther } from "viem";
+import { createWalletClient, custom, erc20Abi, formatEther } from "viem";
 import { celo } from "viem/chains";
 import { useAccount, usePublicClient } from "wagmi";
 import type { MintingFormValues } from "../hypercert-form";
@@ -314,11 +314,13 @@ const MintingProgress = ({
 				),
 			});
 			const [account] = await walletClient.getAddresses();
-			const txhash = await walletClient.sendTransaction({
+			const txhash = await walletClient.writeContract({
 				account,
-				to: GAINFOREST_TIP_ADDRESS,
-				value: GAINFOREST_TIP_AMOUNT,
-				data: `0x${DIVVI_DATA_SUFFIX}`,
+				address: "0x471EcE3750Da237f93B8E339c536989b8978a438", // Celo CELO token address
+				abi: erc20Abi,
+				functionName: "transfer",
+				args: [GAINFOREST_TIP_ADDRESS, GAINFOREST_TIP_AMOUNT],
+				dataSuffix: `0x${DIVVI_DATA_SUFFIX}`,
 			});
 
 			if (txhash) {


### PR DESCRIPTION
# Changes
The transactions for the tip were failing after the divvi suffix was added in the calldata. This issue was fixed by changing the method of sending the transaction.